### PR TITLE
Always use fuzzing, even when approaching mesh_min/max + bug fixes

### DIFF
--- a/Configuration/Adaptive_Mesh.cfg
+++ b/Configuration/Adaptive_Mesh.cfg
@@ -29,8 +29,11 @@ gcode:
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}
     {% set bed_mesh_min = printer.configfile.settings.bed_mesh.mesh_min %}
     {% set bed_mesh_max = printer.configfile.settings.bed_mesh.mesh_max %}
-    {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (printer.configfile.settings.bed_mesh.probe_count[0]-1)  %}
-    {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (printer.configfile.settings.bed_mesh.probe_count[1]-1)  %}
+    # Support both single (same for x and y) and separate probe_count values.
+    {% set probe_count = printer.configfile.settings.bed_mesh.probe_count %}
+    {% set probe_count = probe_count if probe_count|length > 1 else probe_count * 2  %}
+    {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (probe_count[0] - 1)  %}
+    {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (probe_count[1] - 1)  %}
     {% set x_min = bed_mesh_min[0] %}
     {% set y_min = bed_mesh_min[1] %}
     {% set x_max = bed_mesh_max[0] %}

--- a/Configuration/Adaptive_Mesh.cfg
+++ b/Configuration/Adaptive_Mesh.cfg
@@ -34,10 +34,10 @@ gcode:
     {% set probe_count = probe_count if probe_count|length > 1 else probe_count * 2  %}
     {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (probe_count[0] - 1)  %}
     {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (probe_count[1] - 1)  %}
-    {% set x_min = bed_mesh_min[0] %}
-    {% set y_min = bed_mesh_min[1] %}
-    {% set x_max = bed_mesh_max[0] %}
-    {% set y_max = bed_mesh_max[1] %}
+    {% set x_min = all_points | map(attribute=0) | min | default(bed_mesh_min[0]) %}
+    {% set y_min = all_points | map(attribute=1) | min | default(bed_mesh_min[1]) %}
+    {% set x_max = all_points | map(attribute=0) | max | default(bed_mesh_max[0]) %}
+    {% set y_max = all_points | map(attribute=1) | max | default(bed_mesh_max[1]) %}
     
     { action_respond_info("{} points, clamping to mesh [{!r} {!r}]".format(
         all_points | count,
@@ -46,18 +46,16 @@ gcode:
     )) }
 
     {% if fuzz_enable == True %}
-        {% if all_points %}
-            {% set fuzz_range = range(fuzz_min * 100 | int, fuzz_max * 100 | int + 1) %}
-            {% set x_min = ( bed_mesh_min[0], ((all_points | map(attribute=0) | min - (fuzz_range | random / 100.0)) | default(bed_mesh_min[0])) ) | max %}
-            {% set y_min = ( bed_mesh_min[1], ((all_points | map(attribute=1) | min - (fuzz_range | random / 100.0)) | default(bed_mesh_min[1])) ) | max %}
-            {% set x_max = ( bed_mesh_max[0], ((all_points | map(attribute=0) | max + (fuzz_range | random / 100.0)) | default(bed_mesh_max[0])) ) | min %}
-            {% set y_max = ( bed_mesh_max[1], ((all_points | map(attribute=1) | max + (fuzz_range | random / 100.0)) | default(bed_mesh_max[1])) ) | min %}
-        {% endif %}
+        {% set fuzz_range = range(fuzz_min * 100 | int, fuzz_max * 100 | int + 1) %}
+        {% set x_min = (bed_mesh_min[0] + fuzz_max, x_min) | max - (fuzz_range | random / 100.0) %}
+        {% set y_min = (bed_mesh_min[1] + fuzz_max, y_min) | max - (fuzz_range | random / 100.0) %}
+        {% set x_max = (bed_mesh_max[0] - fuzz_max, x_max) | min + (fuzz_range | random / 100.0) %}
+        {% set y_max = (bed_mesh_max[1] - fuzz_max, y_max) | min + (fuzz_range | random / 100.0) %}
     {% else %}
-        {% set x_min = [ bed_mesh_min[0], (all_points | map(attribute=0) | min | default(bed_mesh_min[0])) ] | max %}
-        {% set y_min = [ bed_mesh_min[1], (all_points | map(attribute=1) | min | default(bed_mesh_min[1])) ] | max %}
-        {% set x_max = [ bed_mesh_max[0], (all_points | map(attribute=0) | max | default(bed_mesh_max[0])) ] | min %}
-        {% set y_max = [ bed_mesh_max[1], (all_points | map(attribute=1) | max | default(bed_mesh_max[1])) ] | min %}
+        {% set x_min = [ bed_mesh_min[0], x_min ] | max %}
+        {% set y_min = [ bed_mesh_min[1], y_min ] | max %}
+        {% set x_max = [ bed_mesh_max[0], x_max ] | min %}
+        {% set y_max = [ bed_mesh_max[1], y_max ] | min %}
     {% endif %}
    
     { action_respond_info("Object bounds, clamped to the bed_mesh: {!r}, {!r}".format(

--- a/Configuration/Adaptive_Mesh.cfg
+++ b/Configuration/Adaptive_Mesh.cfg
@@ -29,8 +29,8 @@ gcode:
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}
     {% set bed_mesh_min = printer.configfile.settings.bed_mesh.mesh_min %}
     {% set bed_mesh_max = printer.configfile.settings.bed_mesh.mesh_max %}
-    {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (printer.configfile.settings.bed_mesh.probe_count[0]-2)  %}
-    {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (printer.configfile.settings.bed_mesh.probe_count[1]-2)  %}
+    {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (printer.configfile.settings.bed_mesh.probe_count[0]-1)  %}
+    {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (printer.configfile.settings.bed_mesh.probe_count[1]-1)  %}
     {% set x_min = bed_mesh_min[0] %}
     {% set y_min = bed_mesh_min[1] %}
     {% set x_max = bed_mesh_max[0] %}
@@ -62,8 +62,8 @@ gcode:
         (x_max, y_max),
     )) }
     
-    {% set points_x = (((x_max - x_min) / max_probe_point_distance_x) | int) + 2 %}
-    {% set points_y = (((y_max - y_min) / max_probe_point_distance_y) | int) + 2 %}
+    {% set points_x = (((x_max - x_min) / max_probe_point_distance_x) | round(method='ceil') | int) + 1 %}
+    {% set points_y = (((y_max - y_min) / max_probe_point_distance_y) | round(method='ceil') | int) + 1 %}
     
     {% if (([points_x, points_y]|max) > 6) %}
         {% set algorithm = "bicubic" %}

--- a/Configuration/Adaptive_Mesh.cfg
+++ b/Configuration/Adaptive_Mesh.cfg
@@ -44,7 +44,7 @@ gcode:
 
     {% if fuzz_enable == True %}
         {% if all_points %}
-            {% set fuzz_range = range(fuzz_min * 100 | int, fuzz_max * 100 | int) %}
+            {% set fuzz_range = range(fuzz_min * 100 | int, fuzz_max * 100 | int + 1) %}
             {% set x_min = ( bed_mesh_min[0], ((all_points | map(attribute=0) | min - (fuzz_range | random / 100.0)) | default(bed_mesh_min[0])) ) | max %}
             {% set y_min = ( bed_mesh_min[1], ((all_points | map(attribute=1) | min - (fuzz_range | random / 100.0)) | default(bed_mesh_min[1])) ) | max %}
             {% set x_max = ( bed_mesh_max[0], ((all_points | map(attribute=0) | max + (fuzz_range | random / 100.0)) | default(bed_mesh_max[0])) ) | min %}


### PR DESCRIPTION
In preparation for Voron TAP, I wanted a mesh solution that always applies some fuzzing to probing locations. While the existing implementation does not do so when the mesh approaches the limits specified in the config.

Also applies some bug fixes / features that I had in my old mesh config. Please take a look at the detailed description in each individual commit.

Closes #12 