### PR TITLE
Add RETRACTION_DISTANCE variable to Line Purge

### DIFF
--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -18,6 +18,7 @@ variable_flow_rate: 12              # Desired flow rate in mm3/s (Around 12 for 
 variable_x_default: 10              # Default X location to purge. If adaptive_enable is True, this is overwritten
 variable_y_default: 10              # Default Y location to purge. If adaptive_enable is True, this is overwritten
 variable_distance_to_object_y: 10   # Y distance in millimeters away from the print area for purging. Must be less than or equal to y_default if adaptive_enable is False
+variable_retraction_distance: -0.5  # Distance to retract after the purge
 
 ### This section is for those who are using Moonraker's Update Manager for KAMP, or want a more verbose macro. ###
 
@@ -34,6 +35,7 @@ gcode:
       { action_respond_info("x_default       : %f" % (x_default))  }
       { action_respond_info("y_default       : %f" % (y_default))  }
       { action_respond_info("distance_to_object_y : %f" % (distance_to_object_y))  }
+      { action_respond_info("retraction_distance : %f" % (retraction_distance))  }
     {% endif %}
 
     {% if adaptive_enable == True %}
@@ -58,7 +60,7 @@ gcode:
     G0 Z{z_height}                                                                      # Move to purge Z height
     M83                                                                                 # Relative extrusion mode
     G1 X{x_origin + line_length} E{purge_amount} F{purge_move_speed}                    # Purge line
-    G1 E-.5 F2100                                                                       # Retract
+    G1 E{retraction_distance} F2100                                                     # Retract
     G92 E0                                                                              # Reset extruder distance
     M82                                                                                 # Absolute extrusion mode
     G0 Z{z_height * 2} F{travel_speed}                                                  # Z hop
@@ -74,3 +76,4 @@ gcode:
     SET_GCODE_VARIABLE MACRO=LINE_PURGE  VARIABLE=x_default     VALUE={params.X_DEFAULT|default(10)|float}
     SET_GCODE_VARIABLE MACRO=LINE_PURGE  VARIABLE=y_default     VALUE={params.Y_DEFAULT|default(10)|float}
     SET_GCODE_VARIABLE MACRO=LINE_PURGE  VARIABLE=distance_to_object_y     VALUE={params.DISTANCE_TO_OBJECT_Y|default(10)|float}
+    SET_GCODE_VARIABLE MACRO=LINE_PURGE  VARIABLE=retraction_distance     VALUE={params.RETRACTION_DISTANCE|default(-0.5)|float}


### PR DESCRIPTION
I want to prim without a brim after doing line-purge, and I noticed it retracts too much so I have a gap in the first layer outer wall. This PR doesn't change the default behavior, but adds an additional configuration variable that can be controlled.