### PR TITLE
Add support for PROFILE= arg in BED_MESH_CALIBRATE

### DIFF
--- a/Configuration/Adaptive_Mesh.cfg
+++ b/Configuration/Adaptive_Mesh.cfg
@@ -19,6 +19,10 @@ variable_fuzz_enable: False             # Enables/disables the use of mesh point
 variable_fuzz_min: 0                    # If enabled, the minimum amount in mm a probe point can be randomized, default is 0.
 variable_fuzz_max: 4                    # If enabled, the maximum amount in mm a probe point can be randomized, default is 4.
 
+### This section is for configuring mesh profile name.
+
+variable_mesh_profile_name: 'default'
+
 ### This section is for configuring a mesh margin, which allows the probed mesh to be expanded outwards from the print area.
 
 variable_margin_enable: False           # Enables/disables adding a margin to the meshed area to pad a mesh out for specific needs, default is False.
@@ -35,8 +39,6 @@ variable_detach_macro: 'Dock_Probe'     # Here is where you define the macro tha
 variable_display_parameters: True       # Display macro paramters in the console, useful for debugging the SETUP_KAMP_MESHING call, or more verbosity.
 
 gcode:
-    {% set mesh_profile_name = params.PROFILE|default('default') %}
-
     {% if display_parameters == True %}
       { action_respond_info("led_enable  : %d" % (led_enable))  }
       { action_respond_info("status_macro: \'%s\'" % (status_macro))  }
@@ -135,6 +137,8 @@ gcode:
   SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=fuzz_enable VALUE={params.FUZZ_ENABLE|default(False)|int}
   SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=fuzz_min    VALUE={params.FUZZ_MIN|default(0)|float}
   SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=fuzz_max    VALUE={params.FUZZ_MAX|default(4)|float}
+
+  SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=mesh_profile_name VALUE='"{params.PROFILE|default('default')|string}"'
 
   SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=probe_dock_enable  VALUE={params.PROBE_DOCK_ENABLE|default(False)|int}
   SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=attach_macro VALUE='"{params.ATTACH_MACRO|default('Attach_Probe')|string}"'

--- a/Configuration/Adaptive_Mesh.cfg
+++ b/Configuration/Adaptive_Mesh.cfg
@@ -35,6 +35,7 @@ variable_detach_macro: 'Dock_Probe'     # Here is where you define the macro tha
 variable_display_parameters: True       # Display macro paramters in the console, useful for debugging the SETUP_KAMP_MESHING call, or more verbosity.
 
 gcode:
+    {% set mesh_profile_name = params.PROFILE|default('default') %}
 
     {% if display_parameters == True %}
       { action_respond_info("led_enable  : %d" % (led_enable))  }
@@ -45,6 +46,7 @@ gcode:
       { action_respond_info("probe_dock_enable: %d" % (probe_dock_enable))  }
       { action_respond_info("attach_macro: \'%s\'" % (attach_macro))  }
       { action_respond_info("detach_macro: \'%s\'" % (detach_macro))  }
+      { action_respond_info("mesh_profile_name: \'%s\'" % (mesh_profile_name)) }
     {% endif %}
     
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}
@@ -118,7 +120,7 @@ gcode:
         {status_macro}              # Set status LEDs
     {% endif %}
 
-    _BED_MESH_CALIBRATE mesh_min={x_min},{y_min} mesh_max={x_max},{y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y} RELATIVE_REFERENCE_INDEX={ref_index}
+    _BED_MESH_CALIBRATE mesh_min={x_min},{y_min} mesh_max={x_max},{y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y} RELATIVE_REFERENCE_INDEX={ref_index} PROFILE={mesh_profile_name}
 
     {% if probe_dock_enable == True %}
         {detach_macro}              # Detach/stow a probe if the probe is stored somewhere outside of the print area


### PR DESCRIPTION
add parameter PROFILE= to be able use other than "default" bed mesh name.