### PR TITLE
Update Line_Purge.cfg

### DIFF
--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -37,11 +37,11 @@ gcode:
     {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
 
     # Calculate purge speed
-    {% set purge_move_speed = (flow_rate / cross_section) * 60 | float %}
+    {% set purge_move_speed = (flow_rate / 5.0) * 60 | float %}
 
     {% if cross_section >= 5 %}
 
-        {action_respond_info("[Extruder] max_extrude_cross_section is not configured correctly, please set it to 5. Purge skipped.")}
+        {action_respond_info("[Extruder] max_extrude_cross_section is insufficient for purge, please set it to 5 or greater. Purge skipped.")}
 
     {% else %}
 

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -39,7 +39,7 @@ gcode:
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / 5.0) * 60 | float %}
 
-    {% if cross_section >= 5 %}
+    {% if cross_section <= 5 %}
 
         {action_respond_info("[Extruder] max_extrude_cross_section is insufficient for purge, please set it to 5 or greater. Purge skipped.")}
 

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -39,7 +39,7 @@ gcode:
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / cross_section) * 60 | float %}
 
-    {% if cross_section != 5 %}
+    {% if cross_section >= 5 %}
 
         {action_respond_info("[Extruder] max_extrude_cross_section is not configured correctly, please set it to 5. Purge skipped.")}
 


### PR DESCRIPTION
Changed check for max_extruder_cross_section from != 5 to >= 5 as those who use MMUs will typically have a value greater than 5. Should still satisfy the intended purpose.