### PR TITLE
Update Smart_Park to optionally park at the beginning of the purge line

### DIFF
--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -30,6 +30,7 @@ variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Defau
 
 # The following variables are for adjusting the Smart Park feature for KAMP, which will park the printhead near the print area at a specified height.
 variable_smart_park_height: 10              # Z position for Smart Park, default is 10.
+variable_smart_park_origin: 'default'       # XY origin for Smart Park. Setting it to 'line_purge' or 'voron_purge' will park the printhead at the start of the purge area.
 
 gcode: # Gcode section left intentionally blank. Do not disturb.
 

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -83,7 +83,7 @@ gcode:
             G92 E0                                                                              # Reset extruder
             G0 F{travel_speed}                                                                  # Set travel speed
             G90                                                                                 # Absolute positioning
-            G0 X{purge_x_center} Y{purge_y_origin}                                              # Move to purge position
+            _MOVE_TO_LINE_PURGE_START                                                           # Move to purge position
             G0 Z{purge_height}                                                                  # Move to purge Z height
             M83                                                                                 # Relative extrusion mode
             G1 E{tip_distance} F{purge_move_speed}                                              # Move filament tip
@@ -98,7 +98,7 @@ gcode:
             G92 E0                                                                              # Reset extruder
             G0 F{travel_speed}                                                                  # Set travel speed
             G90                                                                                 # Absolute positioning
-            G0 X{purge_x_origin} Y{purge_y_center}                                              # Move to purge position
+            _MOVE_TO_LINE_PURGE_START                                                           # Move to purge position
             G0 Z{purge_height}                                                                  # Move to purge Z height
             M83                                                                                 # Relative extrusion mode
             G1 E{tip_distance} F{purge_move_speed}                                              # Move filament tip
@@ -110,4 +110,30 @@ gcode:
 
         {% endif %}
     
+    {% endif %}
+
+[gcode_macro _MOVE_TO_LINE_PURGE_START]
+gcode:
+    # Get purge settings from _Kamp_Settings
+    {% set purge_margin = printer["gcode_macro _KAMP_Settings"].purge_margin | float %}
+    {% set purge_amount = printer["gcode_macro _KAMP_Settings"].purge_amount | float %}
+
+
+    # Calculate purge origins and centers from objects
+    {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}    # Get all object points
+    {% set purge_x_min = (all_points | map(attribute=0) | min | default(0)) %}                          # Object x min
+    {% set purge_x_max = (all_points | map(attribute=0) | max | default(0)) %}                          # Object x max
+    {% set purge_y_min = (all_points | map(attribute=1) | min | default(0)) %}                          # Object y min
+    {% set purge_y_max = (all_points | map(attribute=1) | max | default(0)) %}                          # Object y max
+
+    {% set purge_x_center = ([((purge_x_max + purge_x_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on X axis
+    {% set purge_y_center = ([((purge_y_max + purge_y_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on Y axis
+
+    {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
+    {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
+
+    {% if purge_y_origin > 0 %}                                                                         # If there's room on Y, purge along X axis in front of print area 
+        G0 X{purge_x_center} Y{purge_y_origin}                                                          # Move to purge position
+    {% else %}                                                                                          # If there's room on X, purge along Y axis to the left of print area
+        G0 X{purge_x_origin} Y{purge_y_center}                                                          # Move to purge position
     {% endif %}

--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -2,13 +2,23 @@
 description: Parks your printhead near the print area for pre-print hotend heating.
 gcode:
 
-    {% set z_height = printer["gcode_macro _KAMP_Settings"].smart_park_height | float %}                                            # Pull park height value from _KAMP_Settings
-    {% set center_x = printer.toolhead.axis_maximum.x / 2 | float %}                                                                # Create center point of x for fallback
-    {% set center_y = printer.toolhead.axis_maximum.y / 2 | float %}                                                                # Create center point of y for fallback
-    {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}                                # Gather all object points
-    {% set x_min = all_points | map(attribute=0) | min | default(center_x) %}                                                       # Set x_min from smallest object x point
-    {% set y_min = all_points | map(attribute=1) | min | default(center_y) %}                                                       # Set y_min from smallest object y point
-    {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}                                                           # Set travel speed from config
+    {% set park_origin = printer["gcode_macro _KAMP_Settings"].smart_park_origin | default('default') | string %}                       # Pull park origin value from _KAMP_Settings
+    {% set z_height = printer["gcode_macro _KAMP_Settings"].smart_park_height | float %}                                                # Pull park height value from _KAMP_Settings
 
-    G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
-    G0 Z{z_height}                                                                                                                  # Move Z to park height
+    {% if park_origin == 'line_purge' %}                                                                                                # Depending on park origin, move to the correct location
+        _MOVE_TO_LINE_PURGE_START
+        G0 Z{z_height}
+    {% elif park_origin == 'voron_purge' %}
+        _MOVE_TO_VORON_PURGE_START
+        G0 Z{z_height}
+    {% else %}
+        {% set center_x = printer.toolhead.axis_maximum.x / 2 | float %}                                                                # Create center point of x for fallback
+        {% set center_y = printer.toolhead.axis_maximum.y / 2 | float %}                                                                # Create center point of y for fallback
+        {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}                                # Gather all object points
+        {% set x_min = all_points | map(attribute=0) | min | default(center_x) %}                                                       # Set x_min from smallest object x point
+        {% set y_min = all_points | map(attribute=1) | min | default(center_y) %}                                                       # Set y_min from smallest object y point
+        {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}                                                           # Set travel speed from config
+
+        G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
+        G0 Z{z_height}                                                                                                                  # Move Z to park height
+    {% endif %}

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -61,7 +61,7 @@ gcode:
             G92 E0                                                                                      # Reset extruder
             G0 F{travel_speed}                                                                          # Set travel speed
             G90                                                                                         # Absolute positioning
-            G0 X{purge_x_origin} Y{purge_y_origin+size/2}                                               # Move to purge position
+            _MOVE_TO_VORON_PURGE_START                                                                  # Move to purge position
             G0 Z{purge_height}                                                                          # Move to purge Z height
             M83                                                                                         # Relative extrusion mode
             G1 E{tip_distance} F{purge_move_speed}                                                      # Move tip of filament to nozzle
@@ -84,3 +84,19 @@ gcode:
             G0 Z{purge_height*2} F{travel_speed}  
 
     {% endif %}
+
+[gcode_macro _MOVE_TO_VORON_PURGE_START]
+gcode:
+    # Get purge settings from _Kamp_Settings
+    {% set purge_margin = printer["gcode_macro _KAMP_Settings"].purge_margin | float %}
+    {% set size = 10 | float %}
+
+    # Calculate purge origins and centers from objects
+    {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}    # Get all object points
+    {% set purge_x_min = (all_points | map(attribute=0) | min | default(0)) %}                          # Object x min
+    {% set purge_y_min = (all_points | map(attribute=1) | min | default(0)) %}                          # Object y min
+
+    {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
+    {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}
+
+    G0 X{purge_x_origin} Y{purge_y_origin+size/2}                                                       # Move to initial purge position

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <h1 align="center">
   <br>
   <img src="./Photos/Logo/KAMP-Logo.png" width="260"></a>
@@ -28,24 +27,28 @@
 
 ## Key Features:
 
-* No wasted probe information
+- No wasted probe information
+
   - KAMP will generate a mesh **only** in the area you actually need it: Where you're printing!
   - Since the mesh area will be smaller, the mesh can be much more dense. Imagine making a 3x3 mesh, but the size of a [3DBenchy](https://www.3dbenchy.com)!
 
-* Compatibility
+- Compatibility
+
   - If you've got a 3D printer running Klipper and a probe, KAMP is ready to serve you.
   - We've seen users have success with inductive probes, [Klicky](https://github.com/jlas1/Klicky-Probe), [Euclid](https://github.com/nionio6915/Euclid_Probe), BLTouch, and [Voron Tap](https://github.com/VoronDesign/Voron-Tap)
-  
-    >**Note:**
-    >KAMP  has the option to fuzz mesh points, which helps to spread out wear from nozzle-based probing.
-* Straightforward setup
+
+    > **Note:**
+    > KAMP has the option to fuzz mesh points, which helps to spread out wear from nozzle-based probing.
+
+- Straightforward setup
+
   - One of the main goals of KAMP was to be as easy to implement as possible. Just `[include]` a few files, and you're ready to go!
 
+- No parameter passing
 
-* No parameter passing
   - KAMP uses information from [[exclude_object]](https://www.klipper3d.org/Exclude_Object.html#exclude-objects) to define mesh bounds. Complicated slicer parameter passing is finally a thing of the past. Welcome to the future!
 
-* [Adaptive Purging](#adaptive-purging) 
+- [Adaptive Purging](#adaptive-purging)
   - Allows you to purge right next to the print area. We don't believe in boring purges, we like to sign our work with purge logos! We also have provisions for [more simplistic]() purges as well.
 
 <p align="center">
@@ -63,12 +66,13 @@
 1. You will need `[exclude_object]` defined in `printer.cfg`.
 
 2. You will also need to make sure the following is defined in `moonraker.conf`:
-  
-    ```yaml
-    [file_manager]
-    enable_object_processing: True
 
-    ```
+   ```yaml
+   [file_manager]
+   enable_object_processing: True
+
+   ```
+
 3. Finally, you will need to make sure your slicer is labeling objects:
 
 <p align="center">
@@ -84,21 +88,24 @@ If you've got all that, you're ready for KAMP!
 The cleanest and easiest way to get started with KAMP is to use Moonraker's Update Manager utility. This will allow you to easily install and helps to provide future updates when more features are rolled out!
 
 1. `ssh` into your Klipper device and execute the following commands:
+
    ```bash
     cd
-    
+
     git clone https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging.git
-    
+
     ln -s ~/Klipper-Adaptive-Meshing-Purging/Configuration printer_data/config/KAMP
 
     cp ~/Klipper-Adaptive-Meshing-Purging/Configuration/KAMP_Settings.cfg ~/printer_data/config/KAMP_Settings.cfg
-    ```
-    > **Note:**
-    > This will change to the home directory, clone the KAMP repo, create a symbolic link of the repo to your printer's config folder, and create a copy of `KAMP_Settings.cfg` in your config directory, ready to edit.
-    > 
-    > It is also possible that with older setups of klipper or moonraker that your config path will be different. Be sure to use the correct config path for your machine when making the symbolic link, and when copying `KAMP_Settings.cfg` to your config directory.
+   ```
+
+   > **Note:**
+   > This will change to the home directory, clone the KAMP repo, create a symbolic link of the repo to your printer's config folder, and create a copy of `KAMP_Settings.cfg` in your config directory, ready to edit.
+   >
+   > It is also possible that with older setups of klipper or moonraker that your config path will be different. Be sure to use the correct config path for your machine when making the symbolic link, and when copying `KAMP_Settings.cfg` to your config directory.
 
 2. Open your `moonraker.cfg` file and add this configuration:
+
    ```yaml
    [update_manager Klipper-Adaptive-Meshing-Purging]
     type: git_repo
@@ -107,39 +114,39 @@ The cleanest and easiest way to get started with KAMP is to use Moonraker's Upda
     origin: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging.git
     managed_services: klipper
     primary_branch: main
-    ```
+   ```
 
-    > **Note:**
-    > Whenever Moonraker configurations are changed, it must be restarted for changes to take effect. If you do not want moonraker to notify you of future updates to KAMP, feel free to skip this.
+   > **Note:**
+   > Whenever Moonraker configurations are changed, it must be restarted for changes to take effect. If you do not want moonraker to notify you of future updates to KAMP, feel free to skip this.
 
 3. Depending on what features you want from KAMP, you'll need to `[include]` some files in your config:
 
-    ```yaml
-    # This file contains all settings for KAMP, and must be included in printer.cfg with:
+   ```yaml
+   # This file contains all settings for KAMP, and must be included in printer.cfg with:
 
-    [include KAMP_Settings.cfg]
+   [include KAMP_Settings.cfg]
 
-    ### The following [includes] can be uncommented from within KAMP_Settings.cfg. ###
+   ### The following [includes] can be uncommented from within KAMP_Settings.cfg. ###
 
-    # This file enables the use of adaptive meshing.
+   # This file enables the use of adaptive meshing.
 
-    [include ./KAMP/Adaptive_Meshing.cfg]
+   [include ./KAMP/Adaptive_Meshing.cfg]
 
-    # This file enables the use of adaptive line purging.
+   # This file enables the use of adaptive line purging.
 
-    [include ./KAMP/Line_Purge.cfg]
+   [include ./KAMP/Line_Purge.cfg]
 
-    # This file enables the use of the adaptive Voron logo purge.
+   # This file enables the use of the adaptive Voron logo purge.
 
-    [include ./KAMP/Voron_Purge.cfg]
+   [include ./KAMP/Voron_Purge.cfg]
 
-    # This file enables the use of KAMP's Smart Park feature.
+   # This file enables the use of KAMP's Smart Park feature.
 
-    [include ./KAMP/Smart_Park.cfg]
-    ```
+   [include ./KAMP/Smart_Park.cfg]
+   ```
 
-    >**Note:**
-    The KAMP configuration files are broken up like this to allow those who do not use bed probes to benefit from adaptive purging, and other features.
+   > **Note:**
+   > The KAMP configuration files are broken up like this to allow those who do not use bed probes to benefit from adaptive purging, and other features.
 
 4. After you `[include]` the features you want, be sure to restart your firmware so those inclusions take effect.
 
@@ -150,68 +157,72 @@ The cleanest and easiest way to get started with KAMP is to use Moonraker's Upda
 <br>
 
 ## How to use `KAMP_Settings.cfg`:
+
 <br>
 
-  >**Note:**
-  For ease of use and understanding, all KAMP configuration is contained inside of `KAMP_Settings.cfg`. Any changes you wish to make to KAMP specifically can be found here.
+> **Note:**
+> For ease of use and understanding, all KAMP configuration is contained inside of `KAMP_Settings.cfg`. Any changes you wish to make to KAMP specifically can be found here.
 
 <br>
 
 ## Adaptive Meshing:
 
-* Mesh generation and adjustment:
+- Mesh generation and adjustment:
 
-  * These variables affect how KAMP creates meshes:
+  - These variables affect how KAMP creates meshes:
 
-    * `mesh_margin:` This is the amount of space in millimeters **beyond** your print area to further increase the size of the adapted mesh. Rather than a mesh starting at `X50 Y50`, if `Mesh_Margin` is set to `10`, the mesh will be stretched, and the new mesh bounds will start at `X40 Y40` instead. This can be useful for those who commonly use brims when printing. By default, this value is 0.
+    - `mesh_margin:` This is the amount of space in millimeters **beyond** your print area to further increase the size of the adapted mesh. Rather than a mesh starting at `X50 Y50`, if `Mesh_Margin` is set to `10`, the mesh will be stretched, and the new mesh bounds will start at `X40 Y40` instead. This can be useful for those who commonly use brims when printing. By default, this value is 0.
 
-    * `fuzz_amount:` This is the **maximum** amount that the mesh bounds can be increased in millimeters *by random*. This setting is really only intended for those who use a nozzle-based probe like a strain gauge or Voron Tap. This will slightly randomize the bounds of the bed mesh which will help to spread out wear on your print surface when printing multiples of the same print job (several plates of similar size). By default, this value is 0. **Maximum** `fuzz_amount` recommended is `3`.
+    - `fuzz_amount:` This is the **maximum** amount that the mesh bounds can be increased in millimeters _by random_. This setting is really only intended for those who use a nozzle-based probe like a strain gauge or Voron Tap. This will slightly randomize the bounds of the bed mesh which will help to spread out wear on your print surface when printing multiples of the same print job (several plates of similar size). By default, this value is 0. **Maximum** `fuzz_amount` recommended is `3`.
 
 <br>
 
-* Using a probe that is not integrated into the printhead (Klicky, Euclid, etc)
-  
-  * Usually have special macros that are used to attach and detach the probe as it is needed. 
+- Using a probe that is not integrated into the printhead (Klicky, Euclid, etc)
 
-    * `probe_dock_enable:` By default, this setting is `False`. Set this to `True` if your machine has a probe that needs to be attached with a special macro before probing the bed.
+  - Usually have special macros that are used to attach and detach the probe as it is needed.
 
-    * `attach_macro:` Define the macro that your machine uses to attach the probe here.
+    - `probe_dock_enable:` By default, this setting is `False`. Set this to `True` if your machine has a probe that needs to be attached with a special macro before probing the bed.
 
-    * `detach_macro:` Define the macro that your machine uses to detach the probe here.
+    - `attach_macro:` Define the macro that your machine uses to attach the probe here.
+
+    - `detach_macro:` Define the macro that your machine uses to detach the probe here.
 
 ## Adaptive Purging:
 
-* These settings directly affect how KAMP handles it's purge routines and placement:
+- These settings directly affect how KAMP handles it's purge routines and placement:
 
-  * `purge_height:` This is the height above the bed that the nozzle will be when KAMP does it's purge. This should not need much adjustment, unless you are using a nozzle with a large diameter, or purging a very small amount. The default for this value is `0.8`.
-  
-  * `tip_distance:` This is the distance that the very tip of your loaded filament is away from the opening of your nozzle. It's a good idea to tune this value so your purge is nice and consistent, rather than spotty or blown out at the beginning. It's a good idea to set this value to be a little bit less than the final retract that happens in your `Print_End` macro.
+  - `purge_height:` This is the height above the bed that the nozzle will be when KAMP does it's purge. This should not need much adjustment, unless you are using a nozzle with a large diameter, or purging a very small amount. The default for this value is `0.8`.
+
+  - `tip_distance:` This is the distance that the very tip of your loaded filament is away from the opening of your nozzle. It's a good idea to tune this value so your purge is nice and consistent, rather than spotty or blown out at the beginning. It's a good idea to set this value to be a little bit less than the final retract that happens in your `Print_End` macro.
 
 <p align="center">
 <img src="./Photos/Purging-Assets/tip-distance.png" height="350" >
 </p>
 
-  * `purge_margin:` This is the amount of space you wish to have between your purge, and your actual print area. Helpful for those who print using brims or skirts, or have a printhead with ducts that are very close to the bed during the first few layers of a print. By default, this value is `10` as a healthy, but conservative buffer.
+- `purge_margin:` This is the amount of space you wish to have between your purge, and your actual print area. Helpful for those who print using brims or skirts, or have a printhead with ducts that are very close to the bed during the first few layers of a print. By default, this value is `10` as a healthy, but conservative buffer.
 
-  * `purge_amount:` This is the amount in millimeters of filament material you wish to purge prior to a print beginning. Some users prefer only to purge enough to get the nozzle ready, and some users prefer to purge enough to change a filament color before a print. After some testing, the default amount to purge is `30` millimeters of material.
+- `purge_amount:` This is the amount in millimeters of filament material you wish to purge prior to a print beginning. Some users prefer only to purge enough to get the nozzle ready, and some users prefer to purge enough to change a filament color before a print. After some testing, the default amount to purge is `30` millimeters of material.
 
-  * `flow_rate:` This is the desired flow rate you wish to purge at. You should set this value to be close to the flow limit of your hotend. Standard flow hotends like MicroSwiss, Dragonfly, or Revo should be around `12` or so, while higher flow hotends, like the Rapido or Dragon, should be set somewhere around `20`.
+- `flow_rate:` This is the desired flow rate you wish to purge at. You should set this value to be close to the flow limit of your hotend. Standard flow hotends like MicroSwiss, Dragonfly, or Revo should be around `12` or so, while higher flow hotends, like the Rapido or Dragon, should be set somewhere around `20`.
 
-  >**Note:**
-It is required to add `max_extrude_cross_section: 5` to your `[extruder]` config to allow effective purging to be possible. KAMP will warn you if you forget to set this value, and skip the purge so the printer will not be halted. It is also recommended to set up [firmware_retraction](https://www.klipper3d.org/Config_Reference.html?h=retract#firmware_retraction) inside of klipper so KAMP can use the correct retration settings for your machine. If this is not found, KAMP will warn you, and use reasonable direct-drive extruder values to complete the purge.
+> **Note:**
+> It is required to add `max_extrude_cross_section: 5` to your `[extruder]` config to allow effective purging to be possible. KAMP will warn you if you forget to set this value, and skip the purge so the printer will not be halted. It is also recommended to set up [firmware_retraction](https://www.klipper3d.org/Config_Reference.html?h=retract#firmware_retraction) inside of klipper so KAMP can use the correct retration settings for your machine. If this is not found, KAMP will warn you, and use reasonable direct-drive extruder values to complete the purge.
 
 ## Smart Park:
 
-* These settings are used for adjusting KAMP's Smart Park function, which is helpful to move the printhead near the print area to do your final heating.
+- These settings are used for adjusting KAMP's Smart Park function, which is helpful to move the printhead near the print area to do your final heating.
 
-  * `smart_park_height:` This is the height at which you'd like your printhead to be when calling the `Smart_Park` macro. **Don't forget to add `Smart_Park` near the end of your `Print_Start` macro, *before* the final heating command is called.**
+  - `smart_park_height:` This is the height at which you'd like your printhead to be when calling the `Smart_Park` macro. **Don't forget to add `Smart_Park` near the end of your `Print_Start` macro, _before_ the final heating command is called.**
+  - `smart_park_origin:` This is the XY position you'd like your printhead to be when parked. Default is `'default'` and will park just outside the bounds of the object and works independently of any purge command. Setting it to `'line_purge'` or `'voron_purge'` will park it at the beginning of the purge location and is dependent on the associated purge command.
 
 ## Troubleshooting:
-* 
+
+-
 
 ## Credits:
 
 KAMP was not a one man effort, it was made possible with help from fine folks such as:
+
 - [MapleLeafMakers](https://github.com/MapleLeafMakers) - for assisting in the inception of this project.
 - [Julian Schill](https://github.com/julianschill) - A true code warrior and jinja ninja.
 - [KageUrufu](https://github.com/kageurufu) - For spearheading object cancellation in Klipper, and helping make this possible.
@@ -222,11 +233,8 @@ KAMP was not a one man effort, it was made possible with help from fine folks su
 
 ## You may also like...
 
-- [Ellis' Print-Tuning Guide](https://ellis3dp.com/Print-Tuning-Guide/) - A guide for tuning your 3D printer to *perfection*.
+- [Ellis' Print-Tuning Guide](https://ellis3dp.com/Print-Tuning-Guide/) - A guide for tuning your 3D printer to _perfection_.
 - [Jontek2's Print_Start Guide](https://github.com/jontek2/A-better-print_start-macro) - A fantastic `Print_Start` guide for Voron printers.
 - [Takuya's Tools](http://tools.takuya.wtf/index.html) A collection of handy tools for any Klipper user.
 
 ---
-
-
-


### PR DESCRIPTION
### Description
Adds new `Smart_Park` config and logic to optionally park at the start of the purge line. This prevents additional little dots of filament from the printhead oozing in a different location than the purge line.

This is both optional and opt-in. The default behaviour is unchanged.

### How it works
The macro logic for moving to the start of the various purge locations has been pulled into their own hidden macros. This ensures that the purge start logic and the parking logic always stay in sync since they now call the same macro.

If a user has updated their settings for `smart_park_origin` to either `line_purge` or `voron_purge`, those start position macros are called for the X/Y movement and the user's `smart_park_height` is called for the Z. Any value other than `line_purge` or `voron_purge` will result in the unchanged current behaviour.

Choosing to use `line_purge` or `voron_purge` requires that the appropriate cfg files are included (ie: you can't ask for `smart_park_origin: 'line_purge'` without `[include ./KAMP/Line_Purge.cfg]`). The default behaviour is independent of these macros and any purging config, so people who only use `Smart_Park` will be unaffected.