### PR TITLE
Options to set status LEDs during meshing and purging

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -104,7 +104,11 @@ gcode:
     {% if probe_dock_enable == True %}
         {attach_macro}                                                                                                              # Attach/deploy a probe if the probe is stored somewhere outside of the print area
     {% endif %}
-
+    
+    {% if printer['gcode_macro status_meshing'] is defined %}
+        STATUS_MESHING
+    {% endif %}
+    
     _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
 
     {% if probe_dock_enable == True %}

--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -111,6 +111,10 @@ gcode:
     
     _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
 
+    {% if printer['gcode_macro status_ready'] is defined %}
+        STATUS_READY
+    {% endif %}
+
     {% if probe_dock_enable == True %}
         {detach_macro}                                                                                                              # Detach/stow a probe if the probe is stored somewhere outside of the print area
     {% endif %}                                                                                                                     # End of verbose

--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -104,15 +104,15 @@ gcode:
     {% if probe_dock_enable == True %}
         {attach_macro}                                                                                                              # Attach/deploy a probe if the probe is stored somewhere outside of the print area
     {% endif %}
-    
-    {% if printer['gcode_macro status_meshing'] is defined %}
-        STATUS_MESHING
+
+    {% if 'meshing_status_macro' in printer["gcode_macro _KAMP_Settings"] %}
+        {printer["gcode_macro _KAMP_Settings"].meshing_status_macro}
     {% endif %}
-    
+
     _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
 
-    {% if printer['gcode_macro status_ready'] is defined %}
-        STATUS_READY
+    {% if 'ready_status_macro' in printer["gcode_macro _KAMP_Settings"] %}
+        {printer["gcode_macro _KAMP_Settings"].ready_status_macro}
     {% endif %}
 
     {% if probe_dock_enable == True %}

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -11,6 +11,11 @@ description: This macro contains all adjustable settings for KAMP
 # The following variables are settings for KAMP as a whole.
 variable_verbose_enable: True               # Set to True to enable KAMP information output when running. This is useful for debugging.
 
+# The following variables are for setting status LEDs (with Klipper LED Effects for example) during KAMP operations.
+# variable_meshing_status_macro: 'status_meshing'     # Status macro to call before meshing
+# variable_purging_status_macro: 'status_cleaning'    # Status macro to call before purging
+# variable_ready_status_macro: 'status_ready'         # Status macro to call after meshing and purging.
+
 # The following variables are for adjusting adaptive mesh settings for KAMP.
 variable_mesh_margin: 0                     # Expands the mesh size in millimeters if desired. Leave at 0 to disable.
 variable_fuzz_amount: 0                     # Slightly randomizes mesh points to spread out wear from nozzle-based probes. Leave at 0 to disable.

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -118,6 +118,10 @@ gcode:
 
         {% endif %}
 
+        {% if printer['gcode_macro status_ready'] is defined %}
+            STATUS_READY
+        {% endif %}
+
         RESTORE_GCODE_STATE NAME=Prepurge_State                                                 # Restore gcode state
     
     {% endif %}

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -79,7 +79,11 @@ gcode:
         {% endif %}
 
         SAVE_GCODE_STATE NAME=Prepurge_State                                                    # Create gcode state
-
+        
+        {% if printer['gcode_macro status_busy'] is defined %}
+            STATUS_BUSY
+        {% endif %}
+    
         {% if purge_y_origin > 0 %}                                                             # If there's room on Y, purge along X axis in front of print area
 
             G92 E0                                                                              # Reset extruder

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -79,11 +79,11 @@ gcode:
         {% endif %}
 
         SAVE_GCODE_STATE NAME=Prepurge_State                                                    # Create gcode state
-        
-        {% if printer['gcode_macro status_busy'] is defined %}
-            STATUS_BUSY
+
+        {% if 'purging_status_macro' in printer["gcode_macro _KAMP_Settings"] %}
+            {printer["gcode_macro _KAMP_Settings"].purging_status_macro}
         {% endif %}
-    
+
         {% if purge_y_origin > 0 %}                                                             # If there's room on Y, purge along X axis in front of print area
 
             G92 E0                                                                              # Reset extruder
@@ -118,8 +118,8 @@ gcode:
 
         {% endif %}
 
-        {% if printer['gcode_macro status_ready'] is defined %}
-            STATUS_READY
+        {% if 'ready_status_macro' in printer["gcode_macro _KAMP_Settings"] %}
+            {printer["gcode_macro _KAMP_Settings"].ready_status_macro}
         {% endif %}
 
         RESTORE_GCODE_STATE NAME=Prepurge_State                                                 # Restore gcode state

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -59,11 +59,11 @@ gcode:
         {% endif %}
 
             SAVE_GCODE_STATE NAME=Prepurge_State                                                        # Create gcode state
-            
-            {% if printer['gcode_macro status_busy'] is defined %}
-                STATUS_BUSY
+
+            {% if 'purging_status_macro' in printer["gcode_macro _KAMP_Settings"] %}
+                {printer["gcode_macro _KAMP_Settings"].purging_status_macro}
             {% endif %}
-        
+
             G92 E0                                                                                      # Reset extruder
             G0 F{travel_speed}                                                                          # Set travel speed
             G90                                                                                         # Absolute positioning
@@ -89,10 +89,10 @@ gcode:
             M82                                                                                         # Absolute extrusion mode
             G0 Z{purge_height*2} F{travel_speed}                                                        # Z hop
 
-            {% if printer['gcode_macro status_ready'] is defined %}
-                STATUS_READY
+            {% if 'ready_status_macro' in printer["gcode_macro _KAMP_Settings"] %}
+                {printer["gcode_macro _KAMP_Settings"].ready_status_macro}
             {% endif %}
-        
+
             RESTORE_GCODE_STATE NAME=Prepurge_State                                                     # Restore gcode state
 
     {% endif %}

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -59,7 +59,11 @@ gcode:
         {% endif %}
 
             SAVE_GCODE_STATE NAME=Prepurge_State                                                        # Create gcode state
-
+            
+            {% if printer['gcode_macro status_busy'] is defined %}
+                STATUS_BUSY
+            {% endif %}
+        
             G92 E0                                                                                      # Reset extruder
             G0 F{travel_speed}                                                                          # Set travel speed
             G90                                                                                         # Absolute positioning

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -89,6 +89,10 @@ gcode:
             M82                                                                                         # Absolute extrusion mode
             G0 Z{purge_height*2} F{travel_speed}                                                        # Z hop
 
+            {% if printer['gcode_macro status_ready'] is defined %}
+                STATUS_READY
+            {% endif %}
+        
             RESTORE_GCODE_STATE NAME=Prepurge_State                                                     # Restore gcode state
 
     {% endif %}


### PR DESCRIPTION
This restores and extends LED status functionality removed in 11c830dfb71a6a3d83746f5c63b62246eb69aab4. I've added `meshing_status_macro`, `purging_status_macro`, and `ready_status_macro` variables that are each only used if set. These run before meshing, before purging, and after meshing/purging respectively. Without these changes it is impossible for users to enforce status updates during meshing/purging without duplicating the macros entirely. Calling a status macro before meshing does not work when using klicky since klicky's macros set the status LEDs when attaching and docking the probe.