### PR TITLE
add profile to the mesh generated

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -105,7 +105,7 @@ gcode:
         {attach_macro}                                                                                                              # Attach/deploy a probe if the probe is stored somewhere outside of the print area
     {% endif %}
 
-    _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
+    _BED_MESH_CALIBRATE PROFILE=adaptive_mesh mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
 
     {% if probe_dock_enable == True %}
         {detach_macro}                                                                                                              # Detach/stow a probe if the probe is stored somewhere outside of the print area


### PR DESCRIPTION
add a profile name to the `_BED_MESH_CALIBRATE` command so that the generated adaptive mesh dosnt override the default one