### PR TITLE
make smart park macro all caps to match other macros

### DIFF
--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -1,4 +1,4 @@
-[gcode_macro Smart_Park]
+[gcode_macro SMART_PARK]
 description: Parks your printhead near the print area for pre-print hotend heating.
 gcode:
 
@@ -30,3 +30,7 @@ gcode:
 
     G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
     G0 Z{z_height}                                                                                                                  # Move Z to park height 
+
+[gcode_macro Smart_Park]
+gcode:
+    SMART_PARK

--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -30,7 +30,3 @@ gcode:
 
     G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
     G0 Z{z_height}                                                                                                                  # Move Z to park height 
-
-[gcode_macro Smart_Park]
-gcode:
-    SMART_PARK


### PR DESCRIPTION
this was bothering me. i did add a second macro with the old `Smart_Park` name that simply calls the main one to maintain compatibility