### PR TITLE
Move Z before XY when smart parking

### DIFF
--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -28,5 +28,5 @@ gcode:
 
     {% endif %}
 
+    G0 Z{z_height}                                                                                                                  # Move Z to park height
     G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
-    G0 Z{z_height}                                                                                                                  # Move Z to park height 


### PR DESCRIPTION
The XY movements happen real fast and we don't know what height we are at before calling smart_park. Let's be safe rather than sorry and move Z first, so we're not too close or too far from the bed.