### PR TITLE
Changes the minimun to 0, instead of `x_min`/`y_min` when `purge_margin` is defined

### DIFF
--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -14,8 +14,8 @@ gcode:
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}                                                           # Set travel speed from config
 
     {% if purge_margin > 0 and x_min != center_x and y_min != center_y %}                                                           # If objects are detected and purge margin 
-        {% set x_min = [ x_min - purge_margin , x_min ] | max %}                                                                    # value is greater than 0, move
-        {% set y_min = [ y_min - purge_margin , y_min ] | max %}                                                                    # to purge location + margin
+        {% set x_min = [ x_min - purge_margin , 0 ] | max %}                                                                        # value is greater than 0, move
+        {% set y_min = [ y_min - purge_margin , 0 ] | max %}                                                                        # to purge location + margin
     {% endif %}
 
                                                                                                                                     # Verbose park location


### PR DESCRIPTION
The smart parking was always being done right next to the objects, since `x_min` and `y_min` were always being bigger than `x_min - purge_margin` and `y_min - purge_margin`. 
This was causing that my oozing hotend was leaving a blob right on the corner of the object. I realize that it was never using the `purge_margin`.

With this, it will make sure to park within the bed boundaries, and it will honor the `purge_margin` when is defined and within boundaries.

I would suggest that we use it's own variable, instead of reusing the one for the line purge though. Lemme know and I can do it for you