### PR TITLE
Boundary calculations do not take proper account of margins and fuzzing

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -28,10 +28,10 @@ gcode:
     {% set y_max = all_points | map(attribute=1) | max | default(bed_mesh_max[1]) %}                                                # Set y_max from largest object y point
 
     {% set fuzz_range = range((0) | int, (fuzz_amount * 100) | int + 1) %}                                                          # Set fuzz_range between 0 and fuzz_amount
-    {% set adapted_x_min = (bed_mesh_min[0] + fuzz_amount - mesh_margin, x_min) | max - (fuzz_range | random / 100.0) %}            # Adapt x_min to margin and fuzz constraints
-    {% set adapted_y_min = (bed_mesh_min[1] + fuzz_amount - mesh_margin, y_min) | max - (fuzz_range | random / 100.0) %}            # Adapt y_min to margin and fuzz constraints
-    {% set adapted_x_max = (bed_mesh_max[0] - fuzz_amount + mesh_margin, x_max) | min + (fuzz_range | random / 100.0) %}            # Adapt x_max to margin and fuzz constraints
-    {% set adapted_y_max = (bed_mesh_max[1] - fuzz_amount + mesh_margin, y_max) | min + (fuzz_range | random / 100.0) %}            # Adapt y_max to margin and fuzz constraints
+    {% set adapted_x_min = x_min - mesh_margin - (fuzz_range | random / 100.0) %}                                                   # Adapt x_min to margin and fuzz constraints
+    {% set adapted_y_min = y_min - mesh_margin - (fuzz_range | random / 100.0) %}                                                   # Adapt y_min to margin and fuzz constraints
+    {% set adapted_x_max = x_max + mesh_margin + (fuzz_range | random / 100.0) %}                                                   # Adapt x_max to margin and fuzz constraints
+    {% set adapted_y_max = y_max + mesh_margin + (fuzz_range | random / 100.0) %}                                                   # Adapt y_max to margin and fuzz constraints
 
     {% set adapted_x_min = [adapted_x_min , bed_mesh_min[0]] | max %}                                                               # Compare adjustments to defaults and choose max
     {% set adapted_y_min = [adapted_y_min , bed_mesh_min[1]] | max %}                                                               # Compare adjustments to defaults and choose max


### PR DESCRIPTION
The `mesh_margin` and `fuzz_amount` variables seem to have no effect in the development branch. It looks like this probably the case in main as well.

Consider these lines from Adaptive_Meshing.cfg. (I removed the Jinja decorations and comments for clarity.)

```
set adapted_x_min = (bed_mesh_min[0] + fuzz_amount - mesh_margin, x_min) | max - (fuzz_range | random / 100.0)
set adapted_y_min = (bed_mesh_min[1] + fuzz_amount - mesh_margin, y_min) | max - (fuzz_range | random / 100.0)
set adapted_x_max = (bed_mesh_max[0] - fuzz_amount + mesh_margin, x_max) | min + (fuzz_range | random / 100.0)
set adapted_y_max = (bed_mesh_max[1] - fuzz_amount + mesh_margin, y_max) | min + (fuzz_range | random / 100.0)
```

These calculations seem off enough that I suspect there's something about the original intent that I'm not appreciating. So please scrutinize this argument carefully.

First, the boundary checks seem unnecessary given that the next step in the boundary calculations is to clamp the adjusted values to the area specified in `[bed_mesh]`.

Second, modulo boundary-checking, adding the full `fuzz_amount` and then subtracting a random part of it (or vice versa) should be equivalent to just adding or subtracting the random part. And as far as boundary checking goes, the calculations above can certainly yield out-of-bounds values. As a thought experiment, imagine that `fuzz_amount` is 10,000. That will usually result in, e.g., `y_max` being a negative number.

And finally, the fuzz and margin deltas are never actually combined with the original bounds, only the values from `[bed_mesh]`, which seems strange.

Wouldn't the intent be better expressed by this simplified version?

```
set adapted_x_min = x_min - mesh_margin - (fuzz_range | random / 100.0)
set adapted_y_min = y_min - mesh_margin - (fuzz_range | random / 100.0)
set adapted_x_max = x_max + mesh_margin + (fuzz_range | random / 100.0)
set adapted_y_max = y_max + mesh_margin + (fuzz_range | random / 100.0)
```
