### PR TITLE
Typo in flow rate unit

### DIFF
--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -60,7 +60,7 @@ gcode:
 
         {% if purge_y_origin > 0 %}
         
-            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm/s3.".format(                                                                 
+            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
                 (purge_x_center),
                 (purge_y_origin),
                 (purge_amount),
@@ -69,7 +69,7 @@ gcode:
     
         {% else %}
     
-            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm/s3.".format(                                                                 
+            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
                 (purge_x_origin),
                 (purge_y_center),
                 (purge_amount),


### PR DESCRIPTION
There was a typo in the flow rate message printed to the console.

mm/s3 => mm3/s
