### PR TITLE
Add LOCATION option to VORON_PURGE.

### DIFF
--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -27,6 +27,8 @@ variable_tip_distance: 0                    # Distance between tip of filament a
 variable_purge_margin: 10                   # Distance the purge will be in front of the print area, default is 10.
 variable_purge_amount: 30                   # Amount of filament to be purged prior to printing.
 variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Default is 12.
+variable_purge_max_x: 300                   # Max x dimension for your printer (Only needed to purge on the right)
+variable_purge_max_y: 300                   # Max y dimension for your printer (Only needed to purge to the back)
 
 # The following variables are for adjusting the Smart Park feature for KAMP, which will park the printhead near the print area at a specified height.
 variable_smart_park_height: 10              # Z position for Smart Park, default is 10.

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -27,8 +27,10 @@ variable_tip_distance: 0                    # Distance between tip of filament a
 variable_purge_margin: 10                   # Distance the purge will be in front of the print area, default is 10.
 variable_purge_amount: 30                   # Amount of filament to be purged prior to printing.
 variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Default is 12.
-variable_purge_max_x: 300                   # Max x dimension for your printer (Only needed to purge on the right)
-variable_purge_max_y: 300                   # Max y dimension for your printer (Only needed to purge to the back)
+
+# These are REQUIRED if you want to specify a LOCATION for VORON_PURGE
+variable_purge_max_x: -1                    # Max x dimension for your printer (Only needed to purge on the right)
+variable_purge_max_y: -1                    # Max y dimension for your printer (Only needed to purge to the back)
 
 # The following variables are for adjusting the Smart Park feature for KAMP, which will park the printhead near the print area at a specified height.
 variable_smart_park_height: 10              # Z position for Smart Park, default is 10.

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -1,6 +1,8 @@
 [gcode_macro VORON_PURGE]
 description: A purge macro that adapts to be near your actual printed objects
 gcode:
+    {% set location = params.LOCATION|default("LEFT") %}
+
     # Get relevant printer params
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}
     {% set cross_section = printer.configfile.settings.extruder.max_extrude_cross_section | float %}
@@ -22,6 +24,8 @@ gcode:
     {% set purge_margin = kamp_settings.purge_margin | float %}
     {% set purge_amount = kamp_settings.purge_amount | float %}
     {% set flow_rate = kamp_settings.flow_rate | float %}
+    {% set max_x = kamp_settings.purge_max_x | float %}
+    {% set max_y = kamp_settings.purge_max_y | float %}
     {% set size = 10 | float %}
 
     # Calculate purge origins and centers from objects
@@ -34,8 +38,21 @@ gcode:
     {% set purge_x_center = ([((purge_x_max + purge_x_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on X axis
     {% set purge_y_center = ([((purge_y_max + purge_y_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on Y axis
 
-    {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
-    {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
+    {% if location == "LEFT" or location == "FRONT_LEFT" %}
+      {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
+      {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
+    {% elif location == "RIGHT" or location == "FRONT_RIGHT" %}
+      {% set purge_x_origin = ([purge_x_max, max_x - purge_margin] | min) %}                              # Add margin to x min, compare to 0, and choose the larger
+      {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
+    {% elif location == "REAR_LEFT" %}
+      {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
+      {% set purge_y_origin = ([purge_y_max, max_y - purge_margin] | min) %}                                  # Add margin to y min, compare to 0, and choose the larger
+    {% elif location == "REAR_RIGHT" %}
+      {% set purge_x_origin = ([purge_x_max, max_x - purge_margin] | min) %}                                  # Add margin to x min, compare to 0, and choose the larger
+      {% set purge_y_origin = ([purge_y_max, max_y - purge_margin] | min) %}                                  # Add margin to y min, compare to 0, and choose the larger
+    {% else %}
+      {action_raise_error("Invalid LOCATION for VORON_PURGE.  LOCAITON={}".format(location))}
+    {% endif %}
 
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / 5.0) * 60 | float %}

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -24,8 +24,8 @@ gcode:
     {% set purge_margin = kamp_settings.purge_margin | float %}
     {% set purge_amount = kamp_settings.purge_amount | float %}
     {% set flow_rate = kamp_settings.flow_rate | float %}
-    {% set max_x = kamp_settings.purge_max_x | float %}
-    {% set max_y = kamp_settings.purge_max_y | float %}
+    {% set max_x = kamp_settings.purge_max_x | default(-1) | float %}
+    {% set max_y = kamp_settings.purge_max_y | default(-1) | float %}
     {% set size = 10 | float %}
 
     # Calculate purge origins and centers from objects
@@ -42,12 +42,21 @@ gcode:
       {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
       {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
     {% elif location == "RIGHT" or location == "FRONT_RIGHT" %}
+      {% if max_x < 0 %}
+        {action_raise_error("Missing variable_purge_max_x in KAMP_Settings!  Please add variable_purge_max_x to your config.")}
+      {% endif %}
       {% set purge_x_origin = ([purge_x_max, max_x - purge_margin] | min) %}                              # Add margin to x min, compare to 0, and choose the larger
       {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
     {% elif location == "REAR_LEFT" %}
+      {% if max_y < 0 %}
+        {action_raise_error("Missing variable_purge_max_y in KAMP_Settings!  Please add variable_purge_max_y to your config.")}
+      {% endif %}
       {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
       {% set purge_y_origin = ([purge_y_max, max_y - purge_margin] | min) %}                                  # Add margin to y min, compare to 0, and choose the larger
     {% elif location == "REAR_RIGHT" %}
+      {% if max_x < 0 or max_y < 0 %}
+        {action_raise_error("Missing variable_purge_max_x or variable_purge_max_y in KAMP_Settings!  Please add variable_purge_max_x and variable_purge_max_y to your config.")}
+      {% endif %}
       {% set purge_x_origin = ([purge_x_max, max_x - purge_margin] | min) %}                                  # Add margin to x min, compare to 0, and choose the larger
       {% set purge_y_origin = ([purge_y_max, max_y - purge_margin] | min) %}                                  # Add margin to y min, compare to 0, and choose the larger
     {% else %}


### PR DESCRIPTION
Permissible values are:
  - LEFT or FRONT_LEFT (the default and historical location)
  - RIGHT or FRONT_RIGHT (to the right front of the print)
  - REAR_LEFT
  - REAR_RIGHT

New variables have been added to KAMP_Settings.cfg to tell the macro the max X and Y locations for a purge.

This is incredibly useful for IDEX and multi-toolhead printers as each extruder can use a different location to purge.