### PR TITLE
Add option to set bicubic algo selection threshold

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -20,6 +20,7 @@ gcode:
     {% set detach_macro = kamp_settings.detach_macro | string %}                                                                    # Pull detach probe command from _KAMP_Settings
     {% set mesh_margin = kamp_settings.mesh_margin | float %}                                                                       # Pull mesh margin setting from _KAMP_Settings
     {% set fuzz_amount = kamp_settings.fuzz_amount | float %}                                                                       # Pull fuzz amount setting from _KAMP_Settings
+    {% set bicubic_threshold = kamp_settings.bicubic_threshold | int | default(6) %}                                                # Pull bicubic threshold setting from _KAMP_Settings
     {% set probe_count = probe_count if probe_count|length > 1 else probe_count * 2  %}                                             # If probe count is only a single number, convert it to 2. E.g. probe_count:7 = 7,7
     {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (probe_count[0] - 1)  %}                            # Determine max probe point distance
     {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (probe_count[1] - 1)  %}                            # Determine max probe point distance
@@ -42,7 +43,7 @@ gcode:
     {% set points_x = (((adapted_x_max - adapted_x_min) / max_probe_point_distance_x) | round(method='ceil') | int) + 1 %}          # Define probe_count's x point count and round up
     {% set points_y = (((adapted_y_max - adapted_y_min) / max_probe_point_distance_y) | round(method='ceil') | int) + 1 %}          # Define probe_count's y point count and round up
 
-    {% if (([points_x, points_y]|max) > 6) %}                                                                                       # 
+    {% if (([points_x, points_y]|max) > bicubic_threshold) %}                                                                       # 
         {% set algorithm = "bicubic" %}                                                                                             # 
         {% set min_points = 4 %}                                                                                                    # 
     {% else %}                                                                                                                      # Calculate if algorithm should be bicubic or lagrange

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -14,6 +14,7 @@ variable_verbose_enable: True               # Set to True to enable KAMP informa
 # The following variables are for adjusting adaptive mesh settings for KAMP.
 variable_mesh_margin: 0                     # Expands the mesh size in millimeters if desired. Leave at 0 to disable.
 variable_fuzz_amount: 0                     # Slightly randomizes mesh points to spread out wear from nozzle-based probes. Leave at 0 to disable.
+variable_bicubic_threshold: 6               # Bicubic will be selected if at least one axis probe count is greater than specified threshold
 
 # The following variables are for those with a dockable probe like Klicky, Euclid, etc.                 # ----------------  Attach Macro | Detach Macro
 variable_probe_dock_enable: False           # Set to True to enable the usage of a dockable probe.      # ---------------------------------------------


### PR DESCRIPTION
According to observation, if lagrange algorithm is applied to 5 and greater number of points, it produces pretty wavy results near edges. So I prefer to set algo to bicubic if number of probe points exceeds 4. So this threshold allows to set it from the KAMP_settings file.