### PR TITLE
Load KAMP bed mesh by default

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -113,7 +113,8 @@ gcode:
         {attach_macro}                                                                                                              # Attach/deploy a probe if the probe is stored somewhere outside of the print area
     {% endif %}
 
-    _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
+    _BED_MESH_CALIBRATE PROFILE=KAMP mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
+    BED_MESH_PROFILE LOAD=KAMP
 
     {% if probe_dock_enable == True %}
         {detach_macro}                                                                                                              # Detach/stow a probe if the probe is stored somewhere outside of the print area


### PR DESCRIPTION
Added a named profile to bed meshing "KAMP"
Added loading the KAMP profile directly from the mesh macro.

According to klipper docs: "Previous versions of bed_mesh always loaded the profile named default on startup if it was present. This behavior has been removed in favor of allowing the user to determine when a profile is loaded."