### PR TITLE
make sure we are on absolute positioning before parking

### DIFF
--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -32,6 +32,8 @@ gcode:
 
     {% endif %}
 
+    G90                                                                                                                             # Absolute positioning
+    
     {% if printer.toolhead.position.z < z_height %}
         G0 Z{z_height}                                                                                                              # Move Z to park height if current Z position is lower than z_height
     {% endif %}

--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -31,11 +31,14 @@ gcode:
     )) }
 
     {% endif %}
+    
+    SAVE_GCODE_STATE NAME=Presmartpark_State                                                                                        # Create gcode state
 
     G90                                                                                                                             # Absolute positioning
-    
     {% if printer.toolhead.position.z < z_height %}
         G0 Z{z_height}                                                                                                              # Move Z to park height if current Z position is lower than z_height
     {% endif %}
     G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
     G0 Z{z_height}                                                                                                                  # Move Z to park height 
+
+    RESTORE_GCODE_STATE NAME=Presmartpark_State                                                                                        # Restore gcode state

--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -41,4 +41,4 @@ gcode:
     G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
     G0 Z{z_height}                                                                                                                  # Move Z to park height 
 
-    RESTORE_GCODE_STATE NAME=Presmartpark_State                                                                                        # Restore gcode state
+    RESTORE_GCODE_STATE NAME=Presmartpark_State                                                                                     # Restore gcode state


### PR DESCRIPTION
Got a move out of range some times when using smark_park macro.

Line_purge and voron_purge use g90 to make sure nothing goes out of control.
I think smart_park should use it too.