### PR TITLE
Update KAMP_Settings.cfg to remove leading spaces

### DIFF
--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -1,9 +1,9 @@
 # Below you can include specific configuration files depending on what you want KAMP to do:
 
-# [include ./KAMP/Adaptive_Meshing.cfg]       # Include to enable adaptive meshing configuration.
-# [include ./KAMP/Line_Purge.cfg]             # Include to enable adaptive line purging configuration.
-# [include ./KAMP/Voron_Purge.cfg]            # Include to enable adaptive Voron logo purging configuration.
-# [include ./KAMP/Smart_Park.cfg]             # Include to enable the Smart Park function, which parks the printhead near the print area for final heating.
+#[include ./KAMP/Adaptive_Meshing.cfg]       # Include to enable adaptive meshing configuration.
+#[include ./KAMP/Line_Purge.cfg]             # Include to enable adaptive line purging configuration.
+#[include ./KAMP/Voron_Purge.cfg]            # Include to enable adaptive Voron logo purging configuration.
+#[include ./KAMP/Smart_Park.cfg]             # Include to enable the Smart Park function, which parks the printhead near the print area for final heating.
 
 [gcode_macro _KAMP_Settings]
 description: This macro contains all adjustable settings for KAMP 


### PR DESCRIPTION
Remove the leading spaces on the [include]s that trip people up while setting up.