### PR TITLE
Mesh density multiplier

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -20,7 +20,9 @@ gcode:
     {% set detach_macro = kamp_settings.detach_macro | string %}                                                                    # Pull detach probe command from _KAMP_Settings
     {% set mesh_margin = kamp_settings.mesh_margin | float %}                                                                       # Pull mesh margin setting from _KAMP_Settings
     {% set fuzz_amount = kamp_settings.fuzz_amount | float %}                                                                       # Pull fuzz amount setting from _KAMP_Settings
+    {% set mesh_density = kamp_settings.mesh_density | float %}                                                                     # Pull mesh density setting from _KAMP_Settings
     {% set probe_count = probe_count if probe_count|length > 1 else probe_count * 2  %}                                             # If probe count is only a single number, convert it to 2. E.g. probe_count:7 = 7,7
+    {% set probe_count = [ (probe_count[0] * mesh_density) | round(0, 'ceil'), (probe_count[1] * mesh_density) | round(0, 'ceil') ] %}    # Multiply probe_count by mesh density
     {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (probe_count[0] - 1)  %}                            # Determine max probe point distance
     {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (probe_count[1] - 1)  %}                            # Determine max probe point distance
     {% set x_min = all_points | map(attribute=0) | min | default(bed_mesh_min[0]) %}                                                # Set x_min from smallest object x point

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -14,6 +14,7 @@ variable_verbose_enable: True               # Set to True to enable KAMP informa
 # The following variables are for adjusting adaptive mesh settings for KAMP.
 variable_mesh_margin: 0                     # Expands the mesh size in millimeters if desired. Leave at 0 to disable.
 variable_fuzz_amount: 0                     # Slightly randomizes mesh points to spread out wear from nozzle-based probes. Leave at 0 to disable.
+variable_mesh_density: 1                    # Bed mesh density multiplier. If resulting mesh would be 4,4 multipler of 1.5 makes the mesh 6,6. Leave at 1 for default mesh density.
 
 # The following variables are for those with a dockable probe like Klicky, Euclid, etc.                 # ----------------  Attach Macro | Detach Macro
 variable_probe_dock_enable: False           # Set to True to enable the usage of a dockable probe.      # ---------------------------------------------


### PR DESCRIPTION
I've added config for increasing probed mesh density. This might be useful for beds with great variability, or where small prints result in meshes that are not smooth enough.