### PR TITLE
Option to disable probe downsampling (for inductive probe users)

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -20,7 +20,7 @@ gcode:
     {% set detach_macro = kamp_settings.detach_macro | string %}                                                                    # Pull detach probe command from _KAMP_Settings
     {% set mesh_margin = kamp_settings.mesh_margin | float %}                                                                       # Pull mesh margin setting from _KAMP_Settings
     {% set fuzz_amount = kamp_settings.fuzz_amount | float %}                                                                       # Pull fuzz amount setting from _KAMP_Settings
-    {% set downsample_probe_count = kamp_settings.downsample_probe_count  | abs %}
+    {% set scale_probe_count = kamp_settings.scale_probe_count  | abs %}
     {% set probe_count = probe_count if probe_count|length > 1 else probe_count * 2  %}                                             # If probe count is only a single number, convert it to 2. E.g. probe_count:7 = 7,7
     {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (probe_count[0] - 1)  %}                            # Determine max probe point distance
     {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (probe_count[1] - 1)  %}                            # Determine max probe point distance
@@ -40,7 +40,7 @@ gcode:
     {% set adapted_x_max = [adapted_x_max , bed_mesh_max[0]] | min %}                                                               # Compare adjustments to defaults and choose min
     {% set adapted_y_max = [adapted_y_max , bed_mesh_max[1]] | min %}                                                               # Compare adjustments to defaults and choose min
 
-    {% if verbose_enable == True %}                                                                                                     # If enabled downsample probe count, this the default behaviour.
+    {% if scale_probe_count == True %}                                                                                                     # Scales the probe count when enabled, this the default behaviour.
         {% set points_x = (((adapted_x_max - adapted_x_min) / max_probe_point_distance_x) | round(method='ceil') | int) + 1 %}          # Define probe_count's x point count and round up
         {% set points_y = (((adapted_y_max - adapted_y_min) / max_probe_point_distance_y) | round(method='ceil') | int) + 1 %}          # Define probe_count's y point count and round up
     
@@ -73,10 +73,12 @@ gcode:
                 (probe_count[1]),                                                                                                       
             )) }
 
-            { action_respond_info("Adapted probe count: {},{}.".format(                                                                  
-                (points_x),                                                                                                             
-                (points_y),                                                                                                             
-            )) }                                                                                                              
+            {% if scale_probe_count == True %}   
+                { action_respond_info("Adapted probe count: {},{}.".format(                                                                  
+                    (points_x),                                                                                                             
+                    (points_y),                                                                                                             
+                )) } 
+            {% endif %}
 
             {action_respond_info("Default mesh bounds: {}, {}.".format(                                                                  
                 (bed_mesh_min[0],bed_mesh_min[1]),                                                                                      

--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -20,6 +20,7 @@ gcode:
     {% set detach_macro = kamp_settings.detach_macro | string %}                                                                    # Pull detach probe command from _KAMP_Settings
     {% set mesh_margin = kamp_settings.mesh_margin | float %}                                                                       # Pull mesh margin setting from _KAMP_Settings
     {% set fuzz_amount = kamp_settings.fuzz_amount | float %}                                                                       # Pull fuzz amount setting from _KAMP_Settings
+    {% set downsample_probe_count = kamp_settings.downsample_probe_count  | abs %}
     {% set probe_count = probe_count if probe_count|length > 1 else probe_count * 2  %}                                             # If probe count is only a single number, convert it to 2. E.g. probe_count:7 = 7,7
     {% set max_probe_point_distance_x = ( bed_mesh_max[0] - bed_mesh_min[0] ) / (probe_count[0] - 1)  %}                            # Determine max probe point distance
     {% set max_probe_point_distance_y = ( bed_mesh_max[1] - bed_mesh_min[1] ) / (probe_count[1] - 1)  %}                            # Determine max probe point distance
@@ -39,22 +40,27 @@ gcode:
     {% set adapted_x_max = [adapted_x_max , bed_mesh_max[0]] | min %}                                                               # Compare adjustments to defaults and choose min
     {% set adapted_y_max = [adapted_y_max , bed_mesh_max[1]] | min %}                                                               # Compare adjustments to defaults and choose min
 
-    {% set points_x = (((adapted_x_max - adapted_x_min) / max_probe_point_distance_x) | round(method='ceil') | int) + 1 %}          # Define probe_count's x point count and round up
-    {% set points_y = (((adapted_y_max - adapted_y_min) / max_probe_point_distance_y) | round(method='ceil') | int) + 1 %}          # Define probe_count's y point count and round up
-
-    {% if (([points_x, points_y]|max) > 6) %}                                                                                       # 
-        {% set algorithm = "bicubic" %}                                                                                             # 
-        {% set min_points = 4 %}                                                                                                    # 
-    {% else %}                                                                                                                      # Calculate if algorithm should be bicubic or lagrange
-        {% set algorithm = "lagrange" %}                                                                                            # 
-        {% set min_points = 3 %}                                                                                                    # 
-    {% endif %}                                                                                                                     # 
-
-    {% set points_x = [points_x , min_points]|max %}                                                                                # Set probe_count's x points to fit the calculated algorithm
-    {% set points_y = [points_y , min_points]|max %}                                                                                # Set probe_count's y points to fit the calculated algorithm
-    {% set points_x = [points_x , probe_count[0]]|min %}
-    {% set points_y = [points_y , probe_count[1]]|min %}
-
+    {% if verbose_enable == True %}                                                                                                     # If enabled downsample probe count, this the default behaviour.
+        {% set points_x = (((adapted_x_max - adapted_x_min) / max_probe_point_distance_x) | round(method='ceil') | int) + 1 %}          # Define probe_count's x point count and round up
+        {% set points_y = (((adapted_y_max - adapted_y_min) / max_probe_point_distance_y) | round(method='ceil') | int) + 1 %}          # Define probe_count's y point count and round up
+    
+        {% if (([points_x, points_y]|max) > 6) %}                                                                                       # 
+            {% set algorithm = "bicubic" %}                                                                                             # 
+            {% set min_points = 4 %}                                                                                                    # 
+        {% else %}                                                                                                                      # Calculate if algorithm should be bicubic or lagrange
+            {% set algorithm = "lagrange" %}                                                                                            # 
+            {% set min_points = 3 %}                                                                                                    # 
+        {% endif %}                                                                                                                     # 
+        
+        {% set points_x = [points_x , min_points]|max %}                                                                                # Set probe_count's x points to fit the calculated algorithm
+        {% set points_y = [points_y , min_points]|max %}                                                                                # Set probe_count's y points to fit the calculated algorithm
+        {% set points_x = [points_x , probe_count[0]]|min %}
+        {% set points_y = [points_y , probe_count[1]]|min %}
+    {% else %}                                                                                                                          # Use the default probe count from the printer config.
+        {% set points_x = probe_count[0] %}
+        {% set points_y = probe_count[1] %}
+    {% endif %}     
+    
     {% if verbose_enable == True %}                                                                                                 # If verbose is enabled, print information about KAMP's calculations
         {% if printer.exclude_object.objects != [] %}
 

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -14,7 +14,7 @@ variable_verbose_enable: True               # Set to True to enable KAMP informa
 # The following variables are for adjusting adaptive mesh settings for KAMP.
 variable_mesh_margin: 0                     # Expands the mesh size in millimeters if desired. Leave at 0 to disable.
 variable_fuzz_amount: 0                     # Slightly randomizes mesh points to spread out wear from nozzle-based probes. Leave at 0 to disable.
-variable_downsample_probe_points: True      # Downsamples the number of probe points to fit the mesh, this is the classic behaviour. Set to False to disable, this is useful if you are using a scanning probe.
+variable_downsample_probe_count: True      # Downsamples the number of probe points to fit the mesh, this is the classic behaviour. Set to False to disable, this is useful if you are using a scanning probe.
 # The following variables are for those with a dockable probe like Klicky, Euclid, etc.                 # ----------------  Attach Macro | Detach Macro
 variable_probe_dock_enable: False           # Set to True to enable the usage of a dockable probe.      # ---------------------------------------------
 variable_attach_macro: 'Attach_Probe'       # The macro that is used to attach the probe.               # Klicky Probe:   'Attach_Probe' | 'Dock_Probe'

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -14,7 +14,8 @@ variable_verbose_enable: True               # Set to True to enable KAMP informa
 # The following variables are for adjusting adaptive mesh settings for KAMP.
 variable_mesh_margin: 0                     # Expands the mesh size in millimeters if desired. Leave at 0 to disable.
 variable_fuzz_amount: 0                     # Slightly randomizes mesh points to spread out wear from nozzle-based probes. Leave at 0 to disable.
-variable_downsample_probe_count: True      # Downsamples the number of probe points to fit the mesh, this is the classic behaviour. Set to False to disable, this is useful if you are using a scanning probe.
+variable_scale_probe_count: True            # Downsamples the number of probe points to fit the mesh, this is the classic behaviour. Set to False to disable, this is useful if you are using an inductive probe.
+
 # The following variables are for those with a dockable probe like Klicky, Euclid, etc.                 # ----------------  Attach Macro | Detach Macro
 variable_probe_dock_enable: False           # Set to True to enable the usage of a dockable probe.      # ---------------------------------------------
 variable_attach_macro: 'Attach_Probe'       # The macro that is used to attach the probe.               # Klicky Probe:   'Attach_Probe' | 'Dock_Probe'

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -14,7 +14,7 @@ variable_verbose_enable: True               # Set to True to enable KAMP informa
 # The following variables are for adjusting adaptive mesh settings for KAMP.
 variable_mesh_margin: 0                     # Expands the mesh size in millimeters if desired. Leave at 0 to disable.
 variable_fuzz_amount: 0                     # Slightly randomizes mesh points to spread out wear from nozzle-based probes. Leave at 0 to disable.
-
+variable_downsample_probe_points: True      # Downsamples the number of probe points to fit the mesh, this is the classic behaviour. Set to False to disable, this is useful if you are using a scanning probe.
 # The following variables are for those with a dockable probe like Klicky, Euclid, etc.                 # ----------------  Attach Macro | Detach Macro
 variable_probe_dock_enable: False           # Set to True to enable the usage of a dockable probe.      # ---------------------------------------------
 variable_attach_macro: 'Attach_Probe'       # The macro that is used to attach the probe.               # Klicky Probe:   'Attach_Probe' | 'Dock_Probe'


### PR DESCRIPTION
I got a cartographer3d probe and I like scanning meshes with KAMP but the probe count downsampling negates the benefits of my inductive probe.

I have added a new option in KAMP_Settings.cfg that lets you disable the downsampling