### PR TITLE
Allow the Purge Line to be in front or the rear of the object

### DIFF
--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -27,6 +27,7 @@ variable_tip_distance: 0                    # Distance between tip of filament a
 variable_purge_margin: 10                   # Distance the purge will be in front of the print area, default is 10.
 variable_purge_amount: 30                   # Amount of filament to be purged prior to printing.
 variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Default is 12.
+variable_line_purge_orientation: 'front'       # Front or Rear. Default is Front
 
 # The following variables are for adjusting the Smart Park feature for KAMP, which will park the printhead near the print area at a specified height.
 variable_smart_park_height: 10              # Z position for Smart Park, default is 10.

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -27,7 +27,7 @@ variable_tip_distance: 0                    # Distance between tip of filament a
 variable_purge_margin: 10                   # Distance the purge will be in front of the print area, default is 10.
 variable_purge_amount: 30                   # Amount of filament to be purged prior to printing.
 variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Default is 12.
-variable_line_purge_orientation: 'front'       # Front or Rear. Default is Front
+variable_line_purge_orientation: 'front'    # Front or Rear. Default is Front
 
 # The following variables are for adjusting the Smart Park feature for KAMP, which will park the printhead near the print area at a specified height.
 variable_smart_park_height: 10              # Z position for Smart Park, default is 10.

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -21,7 +21,7 @@ gcode:
     {% set purge_margin = printer["gcode_macro _KAMP_Settings"].purge_margin | float %}
     {% set purge_amount = printer["gcode_macro _KAMP_Settings"].purge_amount | float %}
     {% set flow_rate = printer["gcode_macro _KAMP_Settings"].flow_rate | float %}
-    {% set purge_orientation = printer["gcode_macro _KAMP_Settings"].line_purge_orientation | upper %}
+    {% set purge_orientation = printer["gcode_macro _KAMP_Settings"].line_purge_orientation | default("FRONT") | upper %}
     {% set y_max_position = printer.configfile.config["stepper_y"]["position_max"]|float %}
 
     # Calculate purge origins and centers from objects
@@ -31,10 +31,6 @@ gcode:
     {% set purge_x_max = (all_points | map(attribute=0) | max | default(0)) %}                          # Object x max
     {% set purge_y_min = (all_points | map(attribute=1) | min | default(0)) %}                          # Object y min
     {% set purge_y_max = (all_points | map(attribute=1) | max | default(0)) %}                          # Object y max
-    RESPOND TYPE=echo MSG="x_min: {purge_x_min}"
-    RESPOND TYPE=echo MSG="x_max: {purge_x_max}"
-    RESPOND TYPE=echo MSG="y_min: {purge_y_min}"
-    RESPOND TYPE=echo MSG="y_max: {purge_y_max}"
 
 
     {% set purge_x_center = ([((purge_x_max + purge_x_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on X axis
@@ -42,10 +38,9 @@ gcode:
 
     {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
     {% if purge_orientation == "FRONT" %}
-    {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
+        {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                              # Add margin to y min, compare to 0, and choose the larger
     {% elif purge_orientation == "REAR" %}
-    {% set purge_y_origin = ([purge_y_max + purge_margin, y_max_position] | min) %} # Add margin to y max, compare to max y position, and choose the smaller
-
+        {% set purge_y_origin = ([purge_y_max + purge_margin, y_max_position] | min) %} # Add margin to y max, compare to max y position, and choose the smaller
     {% endif %}
 
     # Calculate purge speed

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -21,20 +21,32 @@ gcode:
     {% set purge_margin = printer["gcode_macro _KAMP_Settings"].purge_margin | float %}
     {% set purge_amount = printer["gcode_macro _KAMP_Settings"].purge_amount | float %}
     {% set flow_rate = printer["gcode_macro _KAMP_Settings"].flow_rate | float %}
-
+    {% set purge_orientation = printer["gcode_macro _KAMP_Settings"].line_purge_orientation | upper %}
+    {% set y_max_position = printer.configfile.config["stepper_y"]["position_max"]|float %}
 
     # Calculate purge origins and centers from objects
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}    # Get all object points
+
     {% set purge_x_min = (all_points | map(attribute=0) | min | default(0)) %}                          # Object x min
     {% set purge_x_max = (all_points | map(attribute=0) | max | default(0)) %}                          # Object x max
     {% set purge_y_min = (all_points | map(attribute=1) | min | default(0)) %}                          # Object y min
     {% set purge_y_max = (all_points | map(attribute=1) | max | default(0)) %}                          # Object y max
+    RESPOND TYPE=echo MSG="x_min: {purge_x_min}"
+    RESPOND TYPE=echo MSG="x_max: {purge_x_max}"
+    RESPOND TYPE=echo MSG="y_min: {purge_y_min}"
+    RESPOND TYPE=echo MSG="y_max: {purge_y_max}"
+
 
     {% set purge_x_center = ([((purge_x_max + purge_x_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on X axis
     {% set purge_y_center = ([((purge_y_max + purge_y_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on Y axis
 
     {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
+    {% if purge_orientation == "FRONT" %}
     {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
+    {% elif purge_orientation == "REAR" %}
+    {% set purge_y_origin = ([purge_y_max + purge_margin, y_max_position] | min) %} # Add margin to y max, compare to max y position, and choose the smaller
+
+    {% endif %}
 
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / 5.0) * 60 | float %}


### PR DESCRIPTION
the part cooler on my extruder (sovol sv05, stock extruder setup) tends to collide with the purge line when it is positioned in front of the object. This allows the purge line to be placed at the rear of the object to avoid that collision.