### PR TITLE
several fixes and ramp, wipe, and dynamic speed feature

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -42,13 +42,13 @@ gcode:
     {% set points_x = (((adapted_x_max - adapted_x_min) / max_probe_point_distance_x) | round(method='ceil') | int) + 1 %}          # Define probe_count's x point count and round up
     {% set points_y = (((adapted_y_max - adapted_y_min) / max_probe_point_distance_y) | round(method='ceil') | int) + 1 %}          # Define probe_count's y point count and round up
 
-    {% if (([points_x, points_y]|max) > 6) %}                                                                                       # 
-        {% set algorithm = "bicubic" %}                                                                                             # 
-        {% set min_points = 4 %}                                                                                                    # 
+    {% if (([points_x, points_y]|max) > 6) %}                                                                                       #
+        {% set algorithm = "bicubic" %}                                                                                             #
+        {% set min_points = 4 %}                                                                                                    #
     {% else %}                                                                                                                      # Calculate if algorithm should be bicubic or lagrange
-        {% set algorithm = "lagrange" %}                                                                                            # 
-        {% set min_points = 3 %}                                                                                                    # 
-    {% endif %}                                                                                                                     # 
+        {% set algorithm = "lagrange" %}                                                                                            #
+        {% set min_points = 3 %}                                                                                                    #
+    {% endif %}                                                                                                                     #
 
     {% set points_x = [points_x , min_points]|max %}                                                                                # Set probe_count's x points to fit the calculated algorithm
     {% set points_y = [points_y , min_points]|max %}                                                                                # Set probe_count's y points to fit the calculated algorithm
@@ -58,45 +58,45 @@ gcode:
     {% if verbose_enable == True %}                                                                                                 # If verbose is enabled, print information about KAMP's calculations
         {% if printer.exclude_object.objects != [] %}
 
-            { action_respond_info( "Algorithm: {}.".format(                                                                              
-                (algorithm),                                                                                                            
+            { action_respond_info( "Algorithm: {}.".format(
+                (algorithm),
             )) }
 
-            { action_respond_info("Default probe count: {},{}.".format(                                                                  
-                (probe_count[0]),                                                                                                       
-                (probe_count[1]),                                                                                                       
+            { action_respond_info("Default probe count: {},{}.".format(
+                (probe_count[0]),
+                (probe_count[1]),
             )) }
 
-            { action_respond_info("Adapted probe count: {},{}.".format(                                                                  
-                (points_x),                                                                                                             
-                (points_y),                                                                                                             
-            )) }                                                                                                              
-
-            {action_respond_info("Default mesh bounds: {}, {}.".format(                                                                  
-                (bed_mesh_min[0],bed_mesh_min[1]),                                                                                      
-                (bed_mesh_max[0],bed_mesh_max[1]),                                                                                      
+            { action_respond_info("Adapted probe count: {},{}.".format(
+                (points_x),
+                (points_y),
             )) }
 
-            {% if mesh_margin > 0 %}                                                                                                    
-                {action_respond_info("Mesh margin is {}, mesh bounds extended by {}mm.".format(                                       
-                    (mesh_margin),                                                                                                      
-                    (mesh_margin),                                                                                       
-                )) }                                                                                                                    
-            {% else %}                                                                                                                  
-                {action_respond_info("Mesh margin is 0, margin not increased.")}                                                        
-            {% endif %}                                                                                                                 
+            {action_respond_info("Default mesh bounds: {}, {}.".format(
+                (bed_mesh_min[0],bed_mesh_min[1]),
+                (bed_mesh_max[0],bed_mesh_max[1]),
+            )) }
 
-            {% if fuzz_amount > 0 %}                                                                                                    
-                {action_respond_info("Mesh point fuzzing enabled, points fuzzed up to {}mm.".format(                                     
-                    (fuzz_amount),                                                                                                      
-                )) }                                                                                                                    
-            {% else %}                                                                                                                  
-                {action_respond_info("Fuzz amount is 0, mesh points not fuzzed.")}                                                      
-            {% endif %}                                                                                                                 
+            {% if mesh_margin > 0 %}
+                {action_respond_info("Mesh margin is {}, mesh bounds extended by {}mm.".format(
+                    (mesh_margin),
+                    (mesh_margin),
+                )) }
+            {% else %}
+                {action_respond_info("Mesh margin is 0, margin not increased.")}
+            {% endif %}
 
-            { action_respond_info("Adapted mesh bounds: {}, {}.".format(                                                                 
-                (adapted_x_min, adapted_y_min),                                                                                         
-                (adapted_x_max, adapted_y_max),                                                                                         
+            {% if fuzz_amount > 0 %}
+                {action_respond_info("Mesh point fuzzing enabled, points fuzzed up to {}mm.".format(
+                    (fuzz_amount),
+                )) }
+            {% else %}
+                {action_respond_info("Fuzz amount is 0, mesh points not fuzzed.")}
+            {% endif %}
+
+            { action_respond_info("Adapted mesh bounds: {}, {}.".format(
+                (adapted_x_min, adapted_y_min),
+                (adapted_x_max, adapted_y_max),
             )) }
 
             {action_respond_info("KAMP adjustments successful. Happy KAMPing!")}

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -6,7 +6,7 @@
 #[include ./KAMP/Smart_Park.cfg]             # Include to enable the Smart Park function, which parks the printhead near the print area for final heating.
 
 [gcode_macro _KAMP_Settings]
-description: This macro contains all adjustable settings for KAMP 
+description: This macro contains all adjustable settings for KAMP
 
 # The following variables are settings for KAMP as a whole.
 variable_verbose_enable: True               # Set to True to enable KAMP information output when running. This is useful for debugging.

--- a/Configuration/KAMP_Settings.cfg
+++ b/Configuration/KAMP_Settings.cfg
@@ -27,6 +27,14 @@ variable_tip_distance: 0                    # Distance between tip of filament a
 variable_purge_margin: 10                   # Distance the purge will be in front of the print area, default is 10.
 variable_purge_amount: 30                   # Amount of filament to be purged prior to printing.
 variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Default is 12.
+variable_flow_rate_end: 12                  # Flow rate of purge at the end in mm3/s. Default is 12.
+variable_purge_steps: 1                     # Number of steps in the purge, default is 1.
+variable_purge_length: 30                   # Length of purge line in mm, default is 30.
+variable_purge_ramp_height: 0.8             # Z position of nozzle during purge ramp, default is 0.8.
+variable_purge_ramp_length: 0               # Length of purge ramp in mm, default is 0.
+variable_wipe_height: 0.8                   # Z position of nozzle during wipe, default is 0.8.
+variable_wipe_length: 10                    # Length of wipe in mm, default is 10.
+variable_wipe_speed: 150                    # Speed of wipe in mm/s, default is 150.
 
 # The following variables are for adjusting the Smart Park feature for KAMP, which will park the printhead near the print area at a specified height.
 variable_smart_park_height: 10              # Z position for Smart Park, default is 10.

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -5,6 +5,8 @@ gcode:
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}
     {% set cross_section = printer.configfile.settings.extruder.max_extrude_cross_section | float %}
     {% set filament_diameter = printer.configfile.settings.extruder.filament_diameter | float %}
+    {% set Mx = printer['configfile'].config["stepper_x"]["position_max"] | float %}
+    {% set My = printer['configfile'].config["stepper_y"]["position_max"] | float %}
 
     # Use firmware retraction if it is defined
     {% if printer.firmware_retraction is defined %}
@@ -24,8 +26,18 @@ gcode:
     {% set flow_rate = printer["gcode_macro _KAMP_Settings"].flow_rate | float %}
 
 
+    # calculate actual_purge_length
     {% set pi = 3.1416 %}
     {% set area = (pi * (filament_diameter * 0.5) ** 2) %}
+    {% set max_ratio = (cross_section / area) %}
+    {% set actual_purge_length = ([purge_amount, purge_amount / max_ratio] | max) %}
+    {% set ratio = (purge_amount / actual_purge_length) %}
+
+    {% if actual_purge_length > purge_amount %}
+        {action_respond_info("Purge length is too short for the requested amount of filament. Increasing to {}mm.".format(
+	    (actual_purge_length),
+	)) }
+    {% endif %}
 
     # Calculate purge origins and centers from objects
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}    # Get all object points
@@ -34,14 +46,15 @@ gcode:
     {% set purge_y_min = (all_points | map(attribute=1) | min | default(0)) %}                          # Object y min
     {% set purge_y_max = (all_points | map(attribute=1) | max | default(0)) %}                          # Object y max
 
-    {% set purge_x_center = ([((purge_x_max + purge_x_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on X axis
-    {% set purge_y_center = ([((purge_y_max + purge_y_min) / 2) - (purge_amount / 2), 0] | max) %}      # Create center point of purge line relative to print on Y axis
+    {% set purge_x_center = ([[((purge_x_max + purge_x_min) / 2) - (actual_purge_length / 2) - (10 / 2), 0] | max, Mx - actual_purge_length - 10] | min) %}      # Create center point of purge line relative to print on X axis
+    {% set purge_y_center = ([[((purge_y_max + purge_y_min) / 2) - (actual_purge_length / 2) - (10 / 2), 0] | max, My - actual_purge_length - 10] | min) %}      # Create center point of purge line relative to print on Y axis
 
     {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
     {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
 
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / area) * 60 | float %}
+    {% set purge_travel_speed = (purge_move_speed / ratio) | float %}
 
     {% if purge_y_origin > 0 %}                                                             # If there's room on Y, purge along X axis in front of print area
         {% set purge_x_base = purge_x_center %}
@@ -55,9 +68,9 @@ gcode:
         {% set purge_direction = "Y" %}
     {% endif %}
 
-    {% if cross_section < 5 %}
+    {% if ([purge_x_base, purge_y_base] | min) < 0 %}
 
-        {action_respond_info("[Extruder] max_extrude_cross_section is insufficient for purge, please set it to 5 or greater. Purge skipped.")}
+        {action_respond_info("Purge line is longer than bed size. Purge skipped. Either reduce purge amount or increase [Extruder] max_extrude_cross_section.")}
 
     {% else %}
 
@@ -90,9 +103,9 @@ gcode:
         G0 Z{purge_height}                                                                      # Move to purge Z height
         M83                                                                                     # Relative extrusion mode
         G1 E{tip_distance} F{purge_move_speed}                                                  # Move filament tip
-        G1 {purge_direction}{purge_center + purge_amount} E{purge_amount} F{purge_move_speed}   # Purge line
+        G1 {purge_direction}{purge_center + actual_purge_length} E{purge_amount} F{purge_travel_speed} # Purge line
         {RETRACT}                                                                               # Retract
-        G0 {purge_direction}{purge_center + purge_amount + 10} F{travel_speed}                  # Rapid move to break string
+        G0 {purge_direction}{purge_center + actual_purge_length + 10} F{travel_speed}           # Rapid move to break string
         G92 E0                                                                                  # Reset extruder distance
         M82                                                                                     # Absolute extrusion mode
         G0 Z{purge_height * 2} F{travel_speed}                                                  # Z hop

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -4,6 +4,7 @@ gcode:
     # Get relevant printer params
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}
     {% set cross_section = printer.configfile.settings.extruder.max_extrude_cross_section | float %}
+    {% set filament_diameter = printer.configfile.settings.extruder.filament_diameter | float %}
 
     # Use firmware retraction if it is defined
     {% if printer.firmware_retraction is defined %}
@@ -23,6 +24,9 @@ gcode:
     {% set flow_rate = printer["gcode_macro _KAMP_Settings"].flow_rate | float %}
 
 
+    {% set pi = 3.1416 %}
+    {% set area = (pi * (filament_diameter * 0.5) ** 2) %}
+
     # Calculate purge origins and centers from objects
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}    # Get all object points
     {% set purge_x_min = (all_points | map(attribute=0) | min | default(0)) %}                          # Object x min
@@ -37,7 +41,7 @@ gcode:
     {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
 
     # Calculate purge speed
-    {% set purge_move_speed = (flow_rate / 5.0) * 60 | float %}
+    {% set purge_move_speed = (flow_rate / area) * 60 | float %}
 
     {% if cross_section < 5 %}
 

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -4,7 +4,7 @@ gcode:
     # Get relevant printer params
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}
     {% set cross_section = printer.configfile.settings.extruder.max_extrude_cross_section | float %}
-    
+
     # Use firmware retraction if it is defined
     {% if printer.firmware_retraction is defined %}
         {% set RETRACT = G10 | string %}
@@ -47,8 +47,8 @@ gcode:
 
         {% if verbose_enable == True %}
 
-        {action_respond_info("Moving filament tip {}mms".format(                                                                 
-            (tip_distance),                                                                                      
+        {action_respond_info("Moving filament tip {}mms".format(
+            (tip_distance),
         )) }
         {% endif %}
 
@@ -59,17 +59,17 @@ gcode:
         {% endif %}
 
         {% if purge_y_origin > 0 %}
-        
-            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
+
+            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(
                 (purge_x_center),
                 (purge_y_origin),
                 (purge_amount),
                 (flow_rate),
             )) }
-    
+
         {% else %}
-    
-            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
+
+            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(
                 (purge_x_origin),
                 (purge_y_center),
                 (purge_amount),
@@ -97,7 +97,7 @@ gcode:
             G0 Z{purge_height * 2} F{travel_speed}                                              # Z hop
 
         {% else %}                                                                              # If there's room on X, purge along Y axis to the left of print area
-            
+
             G92 E0                                                                              # Reset extruder
             G0 F{travel_speed}                                                                  # Set travel speed
             G90                                                                                 # Absolute positioning
@@ -115,5 +115,5 @@ gcode:
         {% endif %}
 
         RESTORE_GCODE_STATE NAME=Prepurge_State                                                 # Restore gcode state
-    
+
     {% endif %}

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -24,16 +24,24 @@ gcode:
     {% set purge_margin = printer["gcode_macro _KAMP_Settings"].purge_margin | float %}
     {% set purge_amount = printer["gcode_macro _KAMP_Settings"].purge_amount | float %}
     {% set flow_rate = printer["gcode_macro _KAMP_Settings"].flow_rate | float %}
+    {% set flow_rate_end = printer["gcode_macro _KAMP_Settings"].flow_rate_end | default(flow_rate) | float %}
+    {% set purge_steps = printer["gcode_macro _KAMP_Settings"].purge_steps | default(1) | int %}
+    {% set purge_length = printer["gcode_macro _KAMP_Settings"].purge_length | default(purge_amount) | float %}
+    {% set purge_ramp_height = printer["gcode_macro _KAMP_Settings"].purge_ramp_height | default(purge_height) | float %}
+    {% set purge_ramp_length = printer["gcode_macro _KAMP_Settings"].purge_ramp_length | default(0) | float %}
+    {% set wipe_height = printer["gcode_macro _KAMP_Settings"].wipe_height | default(purge_height) | float %}
+    {% set wipe_length = printer["gcode_macro _KAMP_Settings"].wipe_length | default(10) | float %}
+    {% set wipe_speed = (printer["gcode_macro _KAMP_Settings"].wipe_speed | default(travel_speed / 60) | float) * 60 %}
 
 
     # calculate actual_purge_length
     {% set pi = 3.1416 %}
     {% set area = (pi * (filament_diameter * 0.5) ** 2) %}
     {% set max_ratio = (cross_section / area) %}
-    {% set actual_purge_length = ([purge_amount, purge_amount / max_ratio] | max) %}
+    {% set actual_purge_length = ([purge_length, purge_amount / max_ratio] | max) %}
     {% set ratio = (purge_amount / actual_purge_length) %}
 
-    {% if actual_purge_length > purge_amount %}
+    {% if actual_purge_length > purge_length %}
         {action_respond_info("Purge length is too short for the requested amount of filament. Increasing to {}mm.".format(
 	    (actual_purge_length),
 	)) }
@@ -46,15 +54,29 @@ gcode:
     {% set purge_y_min = (all_points | map(attribute=1) | min | default(0)) %}                          # Object y min
     {% set purge_y_max = (all_points | map(attribute=1) | max | default(0)) %}                          # Object y max
 
-    {% set purge_x_center = ([[((purge_x_max + purge_x_min) / 2) - (actual_purge_length / 2) - (10 / 2), 0] | max, Mx - actual_purge_length - 10] | min) %}      # Create center point of purge line relative to print on X axis
-    {% set purge_y_center = ([[((purge_y_max + purge_y_min) / 2) - (actual_purge_length / 2) - (10 / 2), 0] | max, My - actual_purge_length - 10] | min) %}      # Create center point of purge line relative to print on Y axis
+    {% set purge_x_center = ([[((purge_x_max + purge_x_min) / 2) - (actual_purge_length / 2) - (wipe_length / 2), 0] | max, Mx - actual_purge_length - wipe_length] | min) %}      # Create center point of purge line relative to print on X axis
+    {% set purge_y_center = ([[((purge_y_max + purge_y_min) / 2) - (actual_purge_length / 2) - (wipe_length / 2), 0] | max, My - actual_purge_length - wipe_length] | min) %}      # Create center point of purge line relative to print on Y axis
 
     {% set purge_x_origin = ([purge_x_min - purge_margin, 0] | max) %}                                  # Add margin to x min, compare to 0, and choose the larger
     {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
 
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / area) * 60 | float %}
+    {% set purge_move_speed_end = (flow_rate_end / area) * 60 | float %}
     {% set purge_travel_speed = (purge_move_speed / ratio) | float %}
+    {% set purge_travel_speed_end = (purge_move_speed_end / ratio) | float %}
+
+    {% if purge_steps == 1 %}
+        {% if flow_rate_end != flow_rate %}
+            {action_respond_info("Cannot use variable flow rate with only 1 step. Ignoring flow rate end setting.")}
+        {% endif %}
+        {% set purge_travel_speed_increment = 0 %}
+    {% else %}
+        {% set purge_travel_speed_increment = (purge_travel_speed_end - purge_travel_speed) / (purge_steps - 1) %}
+    {% endif %}
+    {% set purge_amount_ramp = purge_amount * purge_ramp_length / actual_purge_length %}
+    {% set purge_amount_step = (purge_amount - purge_amount_ramp) / purge_steps %}
+    {% set purge_length_step = (actual_purge_length - purge_ramp_length) / purge_steps %}
 
     {% if purge_y_origin > 0 %}                                                             # If there's room on Y, purge along X axis in front of print area
         {% set purge_x_base = purge_x_center %}
@@ -100,12 +122,16 @@ gcode:
         G0 F{travel_speed}                                                                      # Set travel speed
         G90                                                                                     # Absolute positioning
         G0 X{purge_x_base} Y{purge_y_base}                                                      # Move to purge position
-        G0 Z{purge_height}                                                                      # Move to purge Z height
+        G0 Z{purge_ramp_height}                                                                 # Move to ramp Z height
         M83                                                                                     # Relative extrusion mode
         G1 E{tip_distance} F{purge_move_speed}                                                  # Move filament tip
-        G1 {purge_direction}{purge_center + actual_purge_length} E{purge_amount} F{purge_travel_speed} # Purge line
+        G1 {purge_direction}{purge_center + purge_ramp_length} Z{purge_height} E{purge_amount_ramp} F{purge_travel_speed} # Ramp down
+        {% for i in range(purge_steps) %}
+            G1 {purge_direction}{purge_center + purge_ramp_length + (i + 1) * purge_length_step} E{purge_amount_step} F{purge_travel_speed + i * purge_travel_speed_increment} # Purge line
+        {% endfor %}
         {RETRACT}                                                                               # Retract
-        G0 {purge_direction}{purge_center + actual_purge_length + 10} F{travel_speed}           # Rapid move to break string
+        G0 {purge_direction}{purge_center + actual_purge_length + (wipe_length / 2)} Z{wipe_height} F{wipe_speed * 60} # Rapid move to break string
+        G0 {purge_direction}{purge_center + actual_purge_length + wipe_length} Z{purge_height} F{wipe_speed * 60}
         G92 E0                                                                                  # Reset extruder distance
         M82                                                                                     # Absolute extrusion mode
         G0 Z{purge_height * 2} F{travel_speed}                                                  # Z hop

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -43,6 +43,18 @@ gcode:
     # Calculate purge speed
     {% set purge_move_speed = (flow_rate / area) * 60 | float %}
 
+    {% if purge_y_origin > 0 %}                                                             # If there's room on Y, purge along X axis in front of print area
+        {% set purge_x_base = purge_x_center %}
+        {% set purge_y_base = purge_y_origin %}
+        {% set purge_center = purge_x_center %}
+        {% set purge_direction = "X" %}
+    {% else %}                                                                              # If there's room on X, purge along Y axis to the left of print area
+        {% set purge_x_base = purge_x_origin %}
+        {% set purge_y_base = purge_y_center %}
+        {% set purge_center = purge_y_center %}
+        {% set purge_direction = "Y" %}
+    {% endif %}
+
     {% if cross_section < 5 %}
 
         {action_respond_info("[Extruder] max_extrude_cross_section is insufficient for purge, please set it to 5 or greater. Purge skipped.")}
@@ -62,61 +74,28 @@ gcode:
             {action_respond_info("KAMP purge is not using firmware retraction, it is recommended to configure it.")}
         {% endif %}
 
-        {% if purge_y_origin > 0 %}
-
-            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(
-                (purge_x_center),
-                (purge_y_origin),
-                (purge_amount),
-                (flow_rate),
-            )) }
-
-        {% else %}
-
-            {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(
-                (purge_x_origin),
-                (purge_y_center),
-                (purge_amount),
-                (flow_rate),
-            )) }
-
-        {% endif %}
+        {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(
+            (purge_x_base),
+            (purge_y_base),
+            (purge_amount),
+            (flow_rate),
+        )) }
 
         SAVE_GCODE_STATE NAME=Prepurge_State                                                    # Create gcode state
 
-        {% if purge_y_origin > 0 %}                                                             # If there's room on Y, purge along X axis in front of print area
-
-            G92 E0                                                                              # Reset extruder
-            G0 F{travel_speed}                                                                  # Set travel speed
-            G90                                                                                 # Absolute positioning
-            G0 X{purge_x_center} Y{purge_y_origin}                                              # Move to purge position
-            G0 Z{purge_height}                                                                  # Move to purge Z height
-            M83                                                                                 # Relative extrusion mode
-            G1 E{tip_distance} F{purge_move_speed}                                              # Move filament tip
-            G1 X{purge_x_center + purge_amount} E{purge_amount} F{purge_move_speed}             # Purge line
-            {RETRACT}                                                                           # Retract
-            G0 X{purge_x_center + purge_amount + 10} F{travel_speed}                            # Rapid move to break string
-            G92 E0                                                                              # Reset extruder distance
-            M82                                                                                 # Absolute extrusion mode
-            G0 Z{purge_height * 2} F{travel_speed}                                              # Z hop
-
-        {% else %}                                                                              # If there's room on X, purge along Y axis to the left of print area
-
-            G92 E0                                                                              # Reset extruder
-            G0 F{travel_speed}                                                                  # Set travel speed
-            G90                                                                                 # Absolute positioning
-            G0 X{purge_x_origin} Y{purge_y_center}                                              # Move to purge position
-            G0 Z{purge_height}                                                                  # Move to purge Z height
-            M83                                                                                 # Relative extrusion mode
-            G1 E{tip_distance} F{purge_move_speed}                                              # Move filament tip
-            G1 Y{purge_y_center + purge_amount} E{purge_amount} F{purge_move_speed}             # Purge line
-            {RETRACT}                                                                           # Retract
-            G0 Y{purge_y_center + purge_amount + 10} F{travel_speed}                            # Rapid move to break string
-            G92 E0                                                                              # Reset extruder distance
-            M82                                                                                 # Absolute extrusion mode
-            G0 Z{purge_height * 2} F{travel_speed}                                              # Z hop
-
-        {% endif %}
+        G92 E0                                                                                  # Reset extruder
+        G0 F{travel_speed}                                                                      # Set travel speed
+        G90                                                                                     # Absolute positioning
+        G0 X{purge_x_base} Y{purge_y_base}                                                      # Move to purge position
+        G0 Z{purge_height}                                                                      # Move to purge Z height
+        M83                                                                                     # Relative extrusion mode
+        G1 E{tip_distance} F{purge_move_speed}                                                  # Move filament tip
+        G1 {purge_direction}{purge_center + purge_amount} E{purge_amount} F{purge_move_speed}   # Purge line
+        {RETRACT}                                                                               # Retract
+        G0 {purge_direction}{purge_center + purge_amount + 10} F{travel_speed}                  # Rapid move to break string
+        G92 E0                                                                                  # Reset extruder distance
+        M82                                                                                     # Absolute extrusion mode
+        G0 Z{purge_height * 2} F{travel_speed}                                                  # Z hop
 
         RESTORE_GCODE_STATE NAME=Prepurge_State                                                 # Restore gcode state
 

--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -15,7 +15,7 @@ gcode:
     {% set y_min = all_points | map(attribute=1) | min | default(center_y) %}                                                       # Set y_min from smallest object y point
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}                                                           # Set travel speed from config
 
-    {% if purge_margin > 0 and x_min != center_x and y_min != center_y %}                                                           # If objects are detected and purge margin 
+    {% if purge_margin > 0 and x_min != center_x and y_min != center_y %}                                                           # If objects are detected and purge margin
         {% set x_min = [ x_min - purge_margin , x_min ] | min %}                                                                    # value is greater than 0, move
         {% set y_min = [ y_min - purge_margin , y_min ] | min %}                                                                    # to purge location + margin
         {% set x_min = [ x_min , axis_minimum_x ] | max %}
@@ -31,7 +31,7 @@ gcode:
     )) }
 
     {% endif %}
-    
+
     SAVE_GCODE_STATE NAME=Presmartpark_State                                                                                        # Create gcode state
 
     G90                                                                                                                             # Absolute positioning
@@ -39,6 +39,6 @@ gcode:
         G0 Z{z_height}                                                                                                              # Move Z to park height if current Z position is lower than z_height
     {% endif %}
     G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
-    G0 Z{z_height}                                                                                                                  # Move Z to park height 
+    G0 Z{z_height}                                                                                                                  # Move Z to park height
 
     RESTORE_GCODE_STATE NAME=Presmartpark_State                                                                                     # Restore gcode state

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -4,6 +4,7 @@ gcode:
     # Get relevant printer params
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}
     {% set cross_section = printer.configfile.settings.extruder.max_extrude_cross_section | float %}
+    {% set filament_diameter = printer.configfile.settings.extruder.filament_diameter | float %}
 
     # Use firmware retraction if it is defined
     {% if printer.firmware_retraction is defined %}
@@ -24,6 +25,9 @@ gcode:
     {% set flow_rate = kamp_settings.flow_rate | float %}
     {% set size = 10 | float %}
 
+    {% set pi = 3.1416 %}
+    {% set area = (pi * (filament_diameter * 0.5) ** 2) %}
+
     # Calculate purge origins and centers from objects
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}    # Get all object points
     {% set purge_x_min = (all_points | map(attribute=0) | min | default(0)) %}                          # Object x min
@@ -38,7 +42,7 @@ gcode:
     {% set purge_y_origin = ([purge_y_min - purge_margin, 0] | max) %}                                  # Add margin to y min, compare to 0, and choose the larger
 
     # Calculate purge speed
-    {% set purge_move_speed = (flow_rate / 5.0) * 60 | float %}
+    {% set purge_move_speed = (flow_rate / area) * 60 | float %}
 
     {% if cross_section < 5 %}
 

--- a/Configuration/Voron_Purge.cfg
+++ b/Configuration/Voron_Purge.cfg
@@ -4,7 +4,7 @@ gcode:
     # Get relevant printer params
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}
     {% set cross_section = printer.configfile.settings.extruder.max_extrude_cross_section | float %}
-    
+
     # Use firmware retraction if it is defined
     {% if printer.firmware_retraction is defined %}
         {% set RETRACT = G10 | string %}
@@ -48,8 +48,8 @@ gcode:
 
         {% if verbose_enable == True %}
 
-        {action_respond_info("Moving filament tip {}mms".format(                                                                 
-            (tip_distance),                                                                                      
+        {action_respond_info("Moving filament tip {}mms".format(
+            (tip_distance),
         )) }
         {% endif %}
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The cleanest and easiest way to get started with KAMP is to use Moonraker's Upda
   * `flow_rate:` This is the desired flow rate you wish to purge at. You should set this value to be close to the flow limit of your hotend. Standard flow hotends like MicroSwiss, Dragonfly, or Revo should be around `12` or so, while higher flow hotends, like the Rapido or Dragon, should be set somewhere around `20`.
 
   >**Note:**
-It is required to add `max_extrude_cross_section: 5` to your `[extruder]` config to allow effective purging to be possible. KAMP will warn you if you forget to set this value, and skip the purge so the printer will not be halted. It is also recommended to set up [firmware_retraction](https://www.klipper3d.org/Config_Reference.html?h=retract#firmware_retraction) inside of klipper so KAMP can use the correct retraction settings for your machine. If this is not found, KAMP will warn you, and use reasonable direct-drive extruder values to complete the purge.
+For VORON_PURGE it is required to add `max_extrude_cross_section: 5` to your `[extruder]` config to allow effective purging to be possible. KAMP will warn you if you forget to set this value, and skip the purge so the printer will not be halted. LINE_PURGE no longer has this requirement. It is also recommended to set up [firmware_retraction](https://www.klipper3d.org/Config_Reference.html?h=retract#firmware_retraction) inside of klipper so KAMP can use the correct retraction settings for your machine. If this is not found, KAMP will warn you, and use reasonable direct-drive extruder values to complete the purge.
 
 ## Smart Park:
 


### PR DESCRIPTION
This implements the ramp, wipe, and dynamic speed feature for the line purge as known from Prusa printers.

Additionally, it applied the following fixes to the existing code base:
- Removed all trailing white spaces in the configuration directory.
- Fixed the incorrect calculation of the extrusion speed based on the flow rate setting.
- Refactor the implementation to avoid implementing all G-code commands twice for purging along the X and Y axes.
- Dynamically increase the purge line instead of complaining to the user that Klipper's safety features are not turned off.

Finally, the new features were implemented:
- ramp: We start the purge far away from the sheet and approach the sheet slowly when starting the purge line. This is less stressful for the sheet since it does not keep the hot nozzle close to it while moving the tip initially and tends to be less messy in case too much filament gets moved. Additionally, this allows for easier peeling of the purge line after the print.
- wipe: We approach the sheet more closely during the final move after we have completed the purge line. This results in an even cleaner nozzle after the process.
- dynamic speed: Prusa increases the purging speed while creating the purge line. Honestly, I don't know what the benefit is of that approach but for completeness sake, I also implemented that one. This feature requires splitting the creation of the purge line into multiple steps, which has the added benefit for people with really large purge amounts, which gets split over multiple commands, preventing the extruder from running into maximum extrusion limits.
    
All the new settings for those features are implemented in a way that (old) configuration files missing those settings do not cause errors but make the settings default to settings that closely resemble the original behavior without those features enabled.

