### PR TITLE
fix: round numbers for printing

### DIFF
--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -61,19 +61,19 @@ gcode:
         {% if purge_y_origin > 0 %}
         
             {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
-                (purge_x_center),
-                (purge_y_origin),
-                (purge_amount),
-                (flow_rate),
+                (purge_x_center | round(3)),
+                (purge_y_origin | round(3)),
+                (purge_amount | round(1)),
+                (flow_rate | round(1)),
             )) }
     
         {% else %}
     
             {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
-                (purge_x_origin),
-                (purge_y_center),
-                (purge_amount),
-                (flow_rate),
+                (purge_x_origin | round(3)),
+                (purge_y_center | round(3)),
+                (purge_amount | round(1)),,
+                (flow_rate | round(1)),
             )) }
 
         {% endif %}

--- a/Configuration/Line_Purge.cfg
+++ b/Configuration/Line_Purge.cfg
@@ -72,7 +72,7 @@ gcode:
             {action_respond_info("KAMP purge starting at {}, {} and purging {}mm of filament, requested flow rate is {}mm3/s.".format(                                                                 
                 (purge_x_origin | round(3)),
                 (purge_y_center | round(3)),
-                (purge_amount | round(1)),,
+                (purge_amount | round(1)),
                 (flow_rate | round(1)),
             )) }
 


### PR DESCRIPTION
this helps with printing 

// KAMP purge starting at 84.79194999999999, 100.482 and purging 120.0mm of filament, requested flow rate is 12.0mm3/s.