### PR TITLE
Allow Smart Park to be in front or rear of the object

### DIFF
--- a/Configuration/Smart_Park.cfg
+++ b/Configuration/Smart_Park.cfg
@@ -10,24 +10,34 @@ gcode:
     {% set center_y = printer.toolhead.axis_maximum.y / 2 | float %}                                                                # Create center point of y for fallback
     {% set axis_minimum_x = printer.toolhead.axis_minimum.x | float %}
     {% set axis_minimum_y = printer.toolhead.axis_minimum.y | float %}
+    {% set axis_maximum_y = printer.toolhead.axis_maximum.y | float %}
     {% set all_points = printer.exclude_object.objects | map(attribute='polygon') | sum(start=[]) %}                                # Gather all object points
     {% set x_min = all_points | map(attribute=0) | min | default(center_x) %}                                                       # Set x_min from smallest object x point
     {% set y_min = all_points | map(attribute=1) | min | default(center_y) %}                                                       # Set y_min from smallest object y point
+    {% set y_max = all_points | map(attribute=1) | max | default(center_y) %}                                                       # Set y_max from biggest object y point
     {% set travel_speed = (printer.toolhead.max_velocity) * 60 | float %}                                                           # Set travel speed from config
+    {% set purge_orientation = kamp_settings.line_purge_orientation | default("FRONT") | upper %}                                   # Allow to flip smart park location
 
     {% if purge_margin > 0 and x_min != center_x and y_min != center_y %}                                                           # If objects are detected and purge margin 
         {% set x_min = [ x_min - purge_margin , x_min ] | min %}                                                                    # value is greater than 0, move
         {% set y_min = [ y_min - purge_margin , y_min ] | min %}                                                                    # to purge location + margin
+        {% set y_max = [ y_max + purge_margin , y_max ] | max %}                                                                    # to purge location + margin
         {% set x_min = [ x_min , axis_minimum_x ] | max %}
         {% set y_min = [ y_min , axis_minimum_y ] | max %}
+        {% set y_max = [ y_max , axis_maximum_y ] | min %}
     {% endif %}
 
+    {% if purge_orientation == "FRONT" %}
+        {% set y_pos = y_min %}
+    {% elif purge_orientation == "REAR" %}
+        {% set y_pos = y_max %}
+    {% endif %}
                                                                                                                                     # Verbose park location
     {% if verbose_enable == True %}
 
     { action_respond_info("Smart Park location: {},{}.".format(
-        (x_min),
-        (y_min),
+        (x_min | round(3)),
+        (y_pos | round(3)),
     )) }
 
     {% endif %}
@@ -38,7 +48,7 @@ gcode:
     {% if printer.toolhead.position.z < z_height %}
         G0 Z{z_height}                                                                                                              # Move Z to park height if current Z position is lower than z_height
     {% endif %}
-    G0 X{x_min} Y{y_min} F{travel_speed}                                                                                            # Move near object area
+    G0 X{x_min} Y{y_pos} F{travel_speed}                                                                                            # Move near object area
     G0 Z{z_height}                                                                                                                  # Move Z to park height 
 
     RESTORE_GCODE_STATE NAME=Presmartpark_State                                                                                     # Restore gcode state


### PR DESCRIPTION
This PR aims to compliment the existing #247 pull request.

It uses `line_purge_orientation` variable that's added there, and also depends on the value being `front` (by default) or `rear`. If the naming gets changed there, it should also be changed here.

Tested with a few prints so far, seems to work correctly

Also minor change added rounding to digits being printed out in verbose to avoid i.e.
> Smart Park location: 79.39999999999999,147.3.