### PR TITLE
Forward caller parameters to _BED_MESH_CALIBRATE (fixes silent METHOD drop with scanning probes)

### DIFF
--- a/Configuration/Adaptive_Meshing.cfg
+++ b/Configuration/Adaptive_Meshing.cfg
@@ -113,7 +113,12 @@ gcode:
         {attach_macro}                                                                                                              # Attach/deploy a probe if the probe is stored somewhere outside of the print area
     {% endif %}
 
-    _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y}
+    {% set passthrough = [] %}                                                                                                      # Forward caller parameters KAMP does not itself compute
+    {% for key in ['METHOD', 'HORIZONTAL_MOVE_Z', 'SCAN_SPEED', 'ADAPTIVE_MARGIN', 'PROFILE'] %}
+        {% if key in params %}{% set _ = passthrough.append(key ~ '=' ~ params[key]) %}{% endif %}
+    {% endfor %}
+
+    _BED_MESH_CALIBRATE mesh_min={adapted_x_min},{adapted_y_min} mesh_max={adapted_x_max},{adapted_y_max} ALGORITHM={algorithm} PROBE_COUNT={points_x},{points_y} {passthrough | join(' ')}
 
     {% if probe_dock_enable == True %}
         {detach_macro}                                                                                                              # Detach/stow a probe if the probe is stored somewhere outside of the print area


### PR DESCRIPTION
## Problem

`Adaptive_Meshing.cfg` renames `BED_MESH_CALIBRATE` and calls the original with only four parameters:

```
_BED_MESH_CALIBRATE mesh_min={...} mesh_max={...} ALGORITHM={...} PROBE_COUNT={...}
```

Everything else the caller passes is dropped. For scanning probes (BTT Eddy, Cartographer, Beacon, BDsensor) this is a **silent** failure rather than an error:

`BED_MESH_CALIBRATE METHOD=rapid_scan` returns `ok`, and Klipper runs the standard point-by-point probing path instead. No error, no warning, no log entry. The only symptom is the mesh taking minutes instead of seconds, which is easy to attribute to anything but the macro.

BTT's Eddy documentation currently instructs users to remove KAMP entirely because of this incompatibility.

The same applies to `HORIZONTAL_MOVE_Z` and `SCAN_SPEED`.

## Fix

Whitelist passthrough of parameters the macro does not compute itself. A whitelist is used rather than `rawparams` because `rawparams` would duplicate the four parameters the macro derives from the print objects.

## Testing

Hardware: BTT Eddy (`probe_eddy_current`) over CAN, Manta M5P + CB1, CoreXZ, 10x10 mesh.

| Call | Before this PR | After this PR |
|---|---|---|
| `BED_MESH_CALIBRATE METHOD=rapid_scan` | 505 s, point-by-point probing, Z sweeping −5..15 mm, no `Beginning rapid surface scan` in the log | **22 s**, `Beginning rapid surface scan at height 2.00...` present, Z stays at scan height |
| `BED_MESH_CALIBRATE` (no `METHOD`) | point-by-point probing | **unchanged** — point-by-point probing, `bed will contact` messages, Z descending, no rapid scan |

Backwards compatible by construction: with none of the whitelisted keys present the passthrough list is empty and the emitted command is identical to today's.
